### PR TITLE
chore: Add Eclipse Foundation contributors to the license header

### DIFF
--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/workflows/dash-scan.yml
+++ b/.github/workflows/dash-scan.yml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/workflows/dast-scan.yaml
+++ b/.github/workflows/dast-scan.yaml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/workflows/publish-new-snapshot.yaml
+++ b/.github/workflows/publish-new-snapshot.yaml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/workflows/scan-pr-title.yaml
+++ b/.github/workflows/scan-pr-title.yaml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/workflows/trigger-docker-publish.yaml
+++ b/.github/workflows/trigger-docker-publish.yaml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/workflows/trigger-maven-publish.yaml
+++ b/.github/workflows/trigger-maven-publish.yaml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/workflows/upgradeability-test.yaml
+++ b/.github/workflows/upgradeability-test.yaml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/charts/tractusx-identityhub-memory/Chart.yaml
+++ b/charts/tractusx-identityhub-memory/Chart.yaml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub-memory/templates/configmap.yaml
+++ b/charts/tractusx-identityhub-memory/templates/configmap.yaml
@@ -1,5 +1,6 @@
 #################################################################################
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub-memory/templates/deployment.yaml
+++ b/charts/tractusx-identityhub-memory/templates/deployment.yaml
@@ -1,5 +1,6 @@
 #
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub-memory/templates/hpa.yaml
+++ b/charts/tractusx-identityhub-memory/templates/hpa.yaml
@@ -1,5 +1,6 @@
 #################################################################################
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub-memory/templates/identityhub-config.yaml
+++ b/charts/tractusx-identityhub-memory/templates/identityhub-config.yaml
@@ -1,5 +1,6 @@
 #################################################################################
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub-memory/templates/ingress.yaml
+++ b/charts/tractusx-identityhub-memory/templates/ingress.yaml
@@ -1,5 +1,6 @@
 #################################################################################
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub-memory/templates/service.yaml
+++ b/charts/tractusx-identityhub-memory/templates/service.yaml
@@ -1,5 +1,6 @@
 #
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub-memory/templates/serviceaccount.yaml
+++ b/charts/tractusx-identityhub-memory/templates/serviceaccount.yaml
@@ -1,5 +1,6 @@
 #################################################################################
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub-memory/templates/tests/test.yaml
+++ b/charts/tractusx-identityhub-memory/templates/tests/test.yaml
@@ -1,5 +1,6 @@
 #
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub-memory/values.yaml
+++ b/charts/tractusx-identityhub-memory/values.yaml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub/Chart.yaml
+++ b/charts/tractusx-identityhub/Chart.yaml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub/templates/configmap.yaml
+++ b/charts/tractusx-identityhub/templates/configmap.yaml
@@ -1,5 +1,6 @@
 #################################################################################
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub/templates/deployment.yaml
+++ b/charts/tractusx-identityhub/templates/deployment.yaml
@@ -1,5 +1,6 @@
 #
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub/templates/hpa.yaml
+++ b/charts/tractusx-identityhub/templates/hpa.yaml
@@ -1,5 +1,6 @@
 #################################################################################
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub/templates/identityhub-config.yaml
+++ b/charts/tractusx-identityhub/templates/identityhub-config.yaml
@@ -1,5 +1,6 @@
 #################################################################################
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub/templates/identityhub-datasource-config.yaml
+++ b/charts/tractusx-identityhub/templates/identityhub-datasource-config.yaml
@@ -1,5 +1,6 @@
 #################################################################################
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub/templates/ingress.yaml
+++ b/charts/tractusx-identityhub/templates/ingress.yaml
@@ -1,5 +1,6 @@
 #################################################################################
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub/templates/service.yaml
+++ b/charts/tractusx-identityhub/templates/service.yaml
@@ -1,5 +1,6 @@
 #
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub/templates/serviceaccount.yaml
+++ b/charts/tractusx-identityhub/templates/serviceaccount.yaml
@@ -1,5 +1,6 @@
 #################################################################################
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub/templates/tests/test.yaml
+++ b/charts/tractusx-identityhub/templates/tests/test.yaml
@@ -1,5 +1,6 @@
 #
   #  Copyright (c) 2025 Cofinity-X
+  #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
   #  See the NOTICE file(s) distributed with this work for additional
   #  information regarding copyright ownership.

--- a/charts/tractusx-identityhub/values.yaml
+++ b/charts/tractusx-identityhub/values.yaml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <!--
   ~   Copyright (c) 2025 Cofinity-X
+  ~   Copyright (c) 2025 Contributors to the Eclipse Foundation
   ~
   ~   See the NOTICE file(s) distributed with this work for additional
   ~   information regarding copyright ownership.

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -2,6 +2,7 @@
 
 <!--
   ~   Copyright (c) 2025 Cofinity-X
+  ~   Copyright (c) 2025 Contributors to the Eclipse Foundation
   ~
   ~   See the NOTICE file(s) distributed with this work for additional
   ~   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/build.gradle.kts
+++ b/extensions/store/sql/migrations/build.gradle.kts
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/AbstractPostgresqlMigrationExtension.java
+++ b/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/AbstractPostgresqlMigrationExtension.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/CredentialResourceMigrationExtension.java
+++ b/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/CredentialResourceMigrationExtension.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/DidResourceMigrationExtension.java
+++ b/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/DidResourceMigrationExtension.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/FlywayManager.java
+++ b/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/FlywayManager.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/HolderCredentialRequestMigrationExtension.java
+++ b/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/HolderCredentialRequestMigrationExtension.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/JtiValidationMigrationExtension.java
+++ b/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/JtiValidationMigrationExtension.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/KeyPairResourceMigrationExtension.java
+++ b/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/KeyPairResourceMigrationExtension.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/ParticipantContextMigrationExtension.java
+++ b/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/ParticipantContextMigrationExtension.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/StsClientMigrationExtension.java
+++ b/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/identityhub/postgresql/migration/StsClientMigrationExtension.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/store/sql/migrations/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,5 +1,6 @@
 #
 #   Copyright (c) 2025 Cofinity-X
+#   Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #   See the NOTICE file(s) distributed with this work for additional
 #   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/identityhub/postgresql/migration/credentialrequest/V0_0_1__Init_HolderCredentialRequest.sql
+++ b/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/identityhub/postgresql/migration/credentialrequest/V0_0_1__Init_HolderCredentialRequest.sql
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/identityhub/postgresql/migration/credentials/V0_0_1__Init_CredentialResource.sql
+++ b/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/identityhub/postgresql/migration/credentials/V0_0_1__Init_CredentialResource.sql
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/identityhub/postgresql/migration/didresource/V0_0_1__Init_DID.sql
+++ b/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/identityhub/postgresql/migration/didresource/V0_0_1__Init_DID.sql
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/identityhub/postgresql/migration/jtivalidation/V0_0_1__Init_StsClient.sql
+++ b/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/identityhub/postgresql/migration/jtivalidation/V0_0_1__Init_StsClient.sql
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/identityhub/postgresql/migration/keypair/V0_0_1__Init_KeyPairResource.sql
+++ b/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/identityhub/postgresql/migration/keypair/V0_0_1__Init_KeyPairResource.sql
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/identityhub/postgresql/migration/participantcontext/V0_0_1__Init_ParticipantContext.sql
+++ b/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/identityhub/postgresql/migration/participantcontext/V0_0_1__Init_ParticipantContext.sql
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/identityhub/postgresql/migration/stsclient/V0_0_1__Init_StsClient.sql
+++ b/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/identityhub/postgresql/migration/stsclient/V0_0_1__Init_StsClient.sql
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 #
 #   Copyright (c) 2025 Cofinity-X
+#   Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #   See the NOTICE file(s) distributed with this work for additional
 #   information regarding copyright ownership.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 #
 #   Copyright (c) 2025 Cofinity-X
+#   Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #   See the NOTICE file(s) distributed with this work for additional
 #   information regarding copyright ownership.

--- a/gradlew
+++ b/gradlew
@@ -2,6 +2,7 @@
 
 #
 #   Copyright (c) 2025 Cofinity-X
+#   Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #   See the NOTICE file(s) distributed with this work for additional
 #   information regarding copyright ownership.

--- a/runtimes/identityhub-memory/build.gradle.kts
+++ b/runtimes/identityhub-memory/build.gradle.kts
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/runtimes/identityhub-memory/src/main/docker/Dockerfile
+++ b/runtimes/identityhub-memory/src/main/docker/Dockerfile
@@ -1,5 +1,6 @@
 #################################################################################
-#  Copyright (c) 202 Cofinity-X
+#  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/runtimes/identityhub-memory/src/main/java/org/eclipse/edc/identityhub/demo/IdentityHubExtension.java
+++ b/runtimes/identityhub-memory/src/main/java/org/eclipse/edc/identityhub/demo/IdentityHubExtension.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/runtimes/identityhub-memory/src/main/java/org/eclipse/edc/identityhub/demo/TxScopeToCriterionTransformer.java
+++ b/runtimes/identityhub-memory/src/main/java/org/eclipse/edc/identityhub/demo/TxScopeToCriterionTransformer.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/runtimes/identityhub-memory/src/main/java/org/eclipse/edc/identityhub/seed/SuperUserSeedExtension.java
+++ b/runtimes/identityhub-memory/src/main/java/org/eclipse/edc/identityhub/seed/SuperUserSeedExtension.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/runtimes/identityhub-memory/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/runtimes/identityhub-memory/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,5 +1,6 @@
 #
 #   Copyright (c) 2025 Cofinity-X
+#   Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #   See the NOTICE file(s) distributed with this work for additional
 #   information regarding copyright ownership.

--- a/runtimes/identityhub-memory/src/test/java/org/eclipse/edc/identityhub/seed/ParticipantContextSeedExtensionTest.java
+++ b/runtimes/identityhub-memory/src/test/java/org/eclipse/edc/identityhub/seed/ParticipantContextSeedExtensionTest.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/runtimes/identityhub/build.gradle.kts
+++ b/runtimes/identityhub/build.gradle.kts
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/runtimes/identityhub/src/main/docker/Dockerfile
+++ b/runtimes/identityhub/src/main/docker/Dockerfile
@@ -1,5 +1,6 @@
 #################################################################################
-#  Copyright (c) 202 Cofinity-X
+#  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/runtimes/identityhub/src/main/java/org/eclipse/edc/identityhub/demo/IdentityHubExtension.java
+++ b/runtimes/identityhub/src/main/java/org/eclipse/edc/identityhub/demo/IdentityHubExtension.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/runtimes/identityhub/src/main/java/org/eclipse/edc/identityhub/demo/TxScopeToCriterionTransformer.java
+++ b/runtimes/identityhub/src/main/java/org/eclipse/edc/identityhub/demo/TxScopeToCriterionTransformer.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/runtimes/identityhub/src/main/java/org/eclipse/edc/identityhub/seed/SuperUserSeedExtension.java
+++ b/runtimes/identityhub/src/main/java/org/eclipse/edc/identityhub/seed/SuperUserSeedExtension.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/runtimes/identityhub/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/runtimes/identityhub/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,5 +1,6 @@
 #
 #   Copyright (c) 2025 Cofinity-X
+#   Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #   See the NOTICE file(s) distributed with this work for additional
 #   information regarding copyright ownership.

--- a/runtimes/identityhub/src/test/java/org/eclipse/edc/identityhub/seed/ParticipantContextSeedExtensionTest.java
+++ b/runtimes/identityhub/src/test/java/org/eclipse/edc/identityhub/seed/ParticipantContextSeedExtensionTest.java
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 /*
  *   Copyright (c) 2025 Cofinity-X
+ *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  *   See the NOTICE file(s) distributed with this work for additional
  *   information regarding copyright ownership.

--- a/tests/deployment/test-helm-values.yaml
+++ b/tests/deployment/test-helm-values.yaml
@@ -1,5 +1,6 @@
 #################################################################################
 #  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.


### PR DESCRIPTION
## WHAT

Add Eclipse Foundation contributors to the license header

## WHY

To comply with the TRG guidelines: https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02#copyright-and-license-header

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes #60 
