### PR TITLE
set default value for JAR build argument

### DIFF
--- a/runtimes/identityhub-memory/Dockerfile
+++ b/runtimes/identityhub-memory/Dockerfile
@@ -19,7 +19,7 @@
 #################################################################################
 
 FROM eclipse-temurin:23_37-jre-alpine
-ARG JAR
+ARG JAR=build/libs/identityhub-memory.jar
 ARG OTEL_JAR
 ARG ADDITIONAL_FILES
 

--- a/runtimes/identityhub/Dockerfile
+++ b/runtimes/identityhub/Dockerfile
@@ -19,7 +19,7 @@
 #################################################################################
 
 FROM eclipse-temurin:23_37-jre-alpine
-ARG JAR
+ARG JAR=build/libs/identityhub.jar
 ARG OTEL_JAR
 ARG ADDITIONAL_FILES
 


### PR DESCRIPTION
## WHAT

Moves the Dockerfile file to the root of the module and sets default JAR argument.

## WHY

Quality of life change to make building docker images easier

Closes #81 
