### PR TITLE
chore: bump chart versions to 0.1.1 and update postgresql image configuration 

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -25,7 +25,7 @@ maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.18
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.19.0, Apache-2.0, approved, #21912
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.19.0, Apache-2.0, approved, #20841
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.18.2, Apache-2.0, approved, #16625
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.19.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.19.0, Apache-2.0, approved, #23299
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.19.0, Apache-2.0, approved, #20840
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.18.2, Apache-2.0, approved, #16623
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.19.0, Apache-2.0, approved, #20839

--- a/charts/tractusx-identityhub-memory/Chart.yaml
+++ b/charts/tractusx-identityhub-memory/Chart.yaml
@@ -36,7 +36,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/tractusx-identityhub/Chart.lock
+++ b/charts/tractusx-identityhub/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.3.5
+  version: 15.2.1
 - name: vault
   repository: https://helm.releases.hashicorp.com
   version: 0.29.1
-digest: sha256:f69e874f271d1c23744bb8d56d225b63bb6fd6c3d5da5c835a6a1a0a44c91b94
-generated: "2025-02-27T15:45:31.628413+01:00"
+digest: sha256:2edeaa6830fad8bfa9e491314b1876a9e5b01e3291889db8f3dcbabaef39ff57
+generated: "2025-09-01T17:36:09.587745529+02:00"

--- a/charts/tractusx-identityhub/Chart.lock
+++ b/charts/tractusx-identityhub/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 15.2.1
+  version: 12.12.10
 - name: vault
   repository: https://helm.releases.hashicorp.com
   version: 0.29.1
-digest: sha256:2edeaa6830fad8bfa9e491314b1876a9e5b01e3291889db8f3dcbabaef39ff57
-generated: "2025-09-01T17:36:09.587745529+02:00"
+digest: sha256:82271ea66702870bddf5b805c10e25c02e37ecd1f77dae299bec5e85d8841ddc
+generated: "2025-09-02T10:31:34.31422816+02:00"

--- a/charts/tractusx-identityhub/Chart.yaml
+++ b/charts/tractusx-identityhub/Chart.yaml
@@ -49,7 +49,7 @@ dependencies:
   # PostgreSQL
   - name: postgresql
     alias: postgresql
-    version: 16.3.5
+    version: 15.2.1
     repository: https://charts.bitnami.com/bitnami
     condition: install.postgresql
   # HashiCorp Vault

--- a/charts/tractusx-identityhub/Chart.yaml
+++ b/charts/tractusx-identityhub/Chart.yaml
@@ -49,7 +49,7 @@ dependencies:
   # PostgreSQL
   - name: postgresql
     alias: postgresql
-    version: 15.2.1
+    version: 12.12.x
     repository: https://charts.bitnami.com/bitnami
     condition: install.postgresql
   # HashiCorp Vault

--- a/charts/tractusx-identityhub/Chart.yaml
+++ b/charts/tractusx-identityhub/Chart.yaml
@@ -36,7 +36,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/tractusx-identityhub/values.yaml
+++ b/charts/tractusx-identityhub/values.yaml
@@ -287,6 +287,11 @@ tests:
   hookDeletePolicy: before-hook-creation,hook-succeeded
 
 postgresql:
+  image:
+    # -- workaround to use bitnamilegacy chart for version 12.12.x till committers align on new postgresql charts
+    repository: bitnamilegacy/postgresql
+    # -- workaround to use bitnamilegacy chart for version 12.12.x till committers align on new postgresql charts
+    tag: 15.4.0-debian-11-r45
   jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/ih"
   primary:
     persistence:

--- a/charts/tractusx-issuerservice-memory/Chart.yaml
+++ b/charts/tractusx-issuerservice-memory/Chart.yaml
@@ -36,7 +36,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/tractusx-issuerservice/Chart.lock
+++ b/charts/tractusx-issuerservice/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.3.5
+  version: 15.2.1
 - name: vault
   repository: https://helm.releases.hashicorp.com
   version: 0.29.1
-digest: sha256:f69e874f271d1c23744bb8d56d225b63bb6fd6c3d5da5c835a6a1a0a44c91b94
-generated: "2025-02-27T15:45:31.628413+01:00"
+digest: sha256:2edeaa6830fad8bfa9e491314b1876a9e5b01e3291889db8f3dcbabaef39ff57
+generated: "2025-09-02T08:40:22.764985358+02:00"

--- a/charts/tractusx-issuerservice/Chart.lock
+++ b/charts/tractusx-issuerservice/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 15.2.1
+  version: 12.12.10
 - name: vault
   repository: https://helm.releases.hashicorp.com
   version: 0.29.1
-digest: sha256:2edeaa6830fad8bfa9e491314b1876a9e5b01e3291889db8f3dcbabaef39ff57
-generated: "2025-09-02T08:40:22.764985358+02:00"
+digest: sha256:82271ea66702870bddf5b805c10e25c02e37ecd1f77dae299bec5e85d8841ddc
+generated: "2025-09-02T10:31:04.944353949+02:00"

--- a/charts/tractusx-issuerservice/Chart.yaml
+++ b/charts/tractusx-issuerservice/Chart.yaml
@@ -49,7 +49,7 @@ dependencies:
   # PostgreSQL
   - name: postgresql
     alias: postgresql
-    version: 16.3.5
+    version: 15.2.1
     repository: https://charts.bitnami.com/bitnami
     condition: install.postgresql
   # HashiCorp Vault

--- a/charts/tractusx-issuerservice/Chart.yaml
+++ b/charts/tractusx-issuerservice/Chart.yaml
@@ -49,7 +49,7 @@ dependencies:
   # PostgreSQL
   - name: postgresql
     alias: postgresql
-    version: 15.2.1
+    version: 12.12.x
     repository: https://charts.bitnami.com/bitnami
     condition: install.postgresql
   # HashiCorp Vault

--- a/charts/tractusx-issuerservice/Chart.yaml
+++ b/charts/tractusx-issuerservice/Chart.yaml
@@ -36,7 +36,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/tractusx-issuerservice/values.yaml
+++ b/charts/tractusx-issuerservice/values.yaml
@@ -284,6 +284,11 @@ tests:
   hookDeletePolicy: before-hook-creation,hook-succeeded
 
 postgresql:
+  image:
+    # -- workaround to use bitnamilegacy chart for version 12.12.x till committers align on new postgresql charts
+    repository: bitnamilegacy/postgresql
+    # -- workaround to use bitnamilegacy chart for version 12.12.x till committers align on new postgresql charts
+    tag: 15.4.0-debian-11-r45
   jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/issuer"
   primary:
     persistence:

--- a/docs/admin/migration-guide.md
+++ b/docs/admin/migration-guide.md
@@ -1,0 +1,40 @@
+# Migration Guide
+
+This migration guide is based on the `chartVersion` of the chart. If you don't rely on the provided helm chart, consider the changes of the chart as mentioned below manually.
+
+> [!WARNING]
+> Bitnami does change their update and versioning policy starting with 2025-08-28. To install the existing charts with its bitnami dependencies, please consider to manually specify the properties `image.repository` and `image.tag` specifying for the following dependencies:
+> 
+> - postgresql (image: bitnamilegacy/postgresql:15.4.0-debian-11-r45)
+> 
+> You have the following options to specify the container image:
+> 
+> 1. Specify in `values.yaml` below `postgresql`.
+> 
+> ```yaml
+> postgresql: 
+>   image: 
+>     repository: bitnamilegacy/postgresql
+>     tag: 15.4.0-debian-11-r45
+> ```
+> 
+> 2. Set during installation.
+> 
+> ```bash
+> helm install puris -n tractusx-dev/puris \
+>   --set postgresql.image.repository=bitnamilegacy/postgresql
+>   --set postgresql.image.tag=15.4.0-debian-11-r45
+> ```
+> 
+> Notes:
+> 
+> - Deploying an older version of the software may have used an older postgresql version. This is NOT applicable for the PURIS charts.
+> - The community is working out on how to resolve the issue.
+
+# NOTICE
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+* SPDX-License-Identifier: CC-BY-4.0
+* SPDX-FileCopyrightText: 2025 Contributors to the Eclipse Foundation
+* Source URL: <https://github.com/eclipse-tractusx/tractus-x-umbrella>


### PR DESCRIPTION
## WHAT

This PR updates the chart versions for several Helm charts and introduces a temporary workaround for PostgreSQL image configuration in the `values.yaml` files of the Identity Hub and Issuer Service charts.

- Explicit PostgreSQL image configuration added in:
  - `charts/tractusx-identityhub/values.yaml`
  - `charts/tractusx-issuerservice/values.yaml`  
  Using `bitnamilegacy/postgresql:15.4.0-debian-11-r45` as a temporary solution.

## WHY

To ensure compatibility and deployment stability after the deprecation of the Bitnami Helm chart repository.  


Closes #129 
