### PR TITLE
docs: Add initial changelog file following Keep a Changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,3 +48,11 @@ For changes in other Tractus-X components, see the [Eclipse Tractus-X Changelog]
 ### Fixed
 
 - Gitflow trigger dockerfile publish by @AYaoZhan in [#91](https://github.com/eclipse-tractusx/tractusx-identityhub/pull/91)
+
+# NOTICE
+
+This work is licensed under the CC-BY-4.0.
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2025 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/tractusx-identityhub


### PR DESCRIPTION
## WHAT

This PR adds an initial CHANGELOG.md file to the repository, structured according to the Keep a Changelog format.

## WHY

Having a changelog helps track and communicate project changes to contributors and users.
Using the Keep a Changelog format ensures consistency, readability, and alignment with semantic versioning practices.
This is the foundation for maintaining transparent release notes going forward.

Closes #77
