### PR TITLE
feat: Rename configmaps

### DIFF
--- a/charts/tractusx-identityhub-memory/Chart.yaml
+++ b/charts/tractusx-identityhub-memory/Chart.yaml
@@ -36,7 +36,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.2.0
+version: v0.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/tractusx-identityhub-memory/templates/deployment.yaml
+++ b/charts/tractusx-identityhub-memory/templates/deployment.yaml
@@ -157,8 +157,10 @@ spec:
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
           {{- end }}
-          {{- if and (or .Values.identityhub.envSecretNames .Values.identityhub.envConfigMapNames) (or (gt (len .Values.identityhub.envSecretNames) 0) (gt (len .Values.identityhub.envConfigMapNames) 0)) }}
           envFrom:
+            - configMapRef:
+                name: {{ include "identityhub.fullname" . }}-config
+          {{- if and (or .Values.identityhub.envSecretNames .Values.identityhub.envConfigMapNames) (or (gt (len .Values.identityhub.envSecretNames) 0) (gt (len .Values.identityhub.envConfigMapNames) 0)) }}
           {{- range $value := .Values.identityhub.envSecretNames }}
             - secretRef:
                 name: {{ $value | quote }}
@@ -176,15 +178,15 @@ spec:
             {{- end }}
             - name: "tmp"
               mountPath: "/tmp"
-            - name: configuration
+            - name: logging-config
               mountPath: /app/logging.properties
               subPath: logging.properties
             - name: logs
               mountPath: {{ .Values.identityhub.logging.path }}
       volumes:
-        - name: "configuration"
+        - name: "logging-config"
           configMap:
-            name: {{ include "identityhub.fullname" . }}
+            name: {{ include "identityhub.fullname" . }}-logging-config
             items:
               - key: "logging.properties"
                 path: "logging.properties"

--- a/charts/tractusx-identityhub-memory/templates/identityhub-config.yaml
+++ b/charts/tractusx-identityhub-memory/templates/identityhub-config.yaml
@@ -26,7 +26,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "identityhub-config"
+  name: {{ include "identityhub.fullname" . }}-config
   namespace: {{ .Release.Namespace | default "default" | quote }}
   labels:
     {{- include "identityhub.labels" . | nindent 4 }}

--- a/charts/tractusx-identityhub-memory/templates/identityhub-config.yaml
+++ b/charts/tractusx-identityhub-memory/templates/identityhub-config.yaml
@@ -1,4 +1,5 @@
 #################################################################################
+  #  Copyright (c) 2026 LKS Next
   #  Copyright (c) 2025 Cofinity-X
   #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #

--- a/charts/tractusx-identityhub-memory/templates/identityhub-logging-config.yaml
+++ b/charts/tractusx-identityhub-memory/templates/identityhub-logging-config.yaml
@@ -1,5 +1,4 @@
 #################################################################################
-  #  Copyright (c) 2025 Cofinity-X
   #  Copyright (c) 2025 LKS Next
   #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
@@ -24,7 +23,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "identityhub.fullname" . }}
+  name: {{ include "identityhub.fullname" . }}-logging-config
   namespace: {{ .Release.Namespace | default "default" | quote }}
   labels:
     {{- include "identityhub.labels" . | nindent 4 }}

--- a/charts/tractusx-identityhub-memory/values.yaml
+++ b/charts/tractusx-identityhub-memory/values.yaml
@@ -176,7 +176,9 @@ identityhub:
   #  - second-secret
 
   # [Kubernetes ConfigMap Resource](https://kubernetes.io/docs/concepts/configuration/configmap/) names to load environment variables from
-  envConfigMapNames: ["identityhub-config"]
+  # Note: The chart automatically includes the built-in ConfigMap (config) with dynamic name based on the release name.
+  # This array is for additional custom ConfigMaps only.
+  envConfigMapNames: []
   #  - first-config-map
   #  - second-config-map
 

--- a/charts/tractusx-identityhub/Chart.yaml
+++ b/charts/tractusx-identityhub/Chart.yaml
@@ -36,7 +36,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.2.0
+version: v0.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/tractusx-identityhub/templates/deployment.yaml
+++ b/charts/tractusx-identityhub/templates/deployment.yaml
@@ -153,8 +153,11 @@ spec:
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
           {{- end }}
-          {{- if and (or .Values.identityhub.envSecretNames .Values.identityhub.envConfigMapNames) (or (gt (len .Values.identityhub.envSecretNames) 0) (gt (len .Values.identityhub.envConfigMapNames) 0)) }}
           envFrom:
+            - configMapRef:
+                name: {{ include "identityhub.fullname" . }}-config
+            - configMapRef:
+                name: {{ include "identityhub.fullname" . }}-datasource-config
           {{- range $value := .Values.identityhub.envSecretNames }}
             - secretRef:
                 name: {{ $value | quote }}
@@ -162,7 +165,6 @@ spec:
           {{- range $value := .Values.identityhub.envConfigMapNames }}
             - configMapRef:
                 name: {{ $value | quote }}
-          {{- end }}
           {{- end }}
           volumeMounts:
             {{- if .Values.customCaCerts }}

--- a/charts/tractusx-identityhub/templates/deployment.yaml
+++ b/charts/tractusx-identityhub/templates/deployment.yaml
@@ -158,6 +158,7 @@ spec:
                 name: {{ include "identityhub.fullname" . }}-config
             - configMapRef:
                 name: {{ include "identityhub.fullname" . }}-datasource-config
+          {{- if and (or .Values.identityhub.envSecretNames .Values.identityhub.envConfigMapNames) (or (gt (len .Values.identityhub.envSecretNames) 0) (gt (len .Values.identityhub.envConfigMapNames) 0)) }}
           {{- range $value := .Values.identityhub.envSecretNames }}
             - secretRef:
                 name: {{ $value | quote }}
@@ -165,6 +166,7 @@ spec:
           {{- range $value := .Values.identityhub.envConfigMapNames }}
             - configMapRef:
                 name: {{ $value | quote }}
+          {{- end }}
           {{- end }}
           volumeMounts:
             {{- if .Values.customCaCerts }}
@@ -174,15 +176,15 @@ spec:
             {{- end }}
             - name: "tmp"
               mountPath: "/tmp"
-            - name : configuration
+            - name : logging-config
               mountPath: /app/logging.properties
               subPath: logging.properties
             - name: logs
               mountPath: {{ .Values.identityhub.logging.path }}
       volumes:
-        - name: "configuration"
+        - name: "logging-config"
           configMap:
-            name: {{ include "identityhub.fullname" . }}
+            name: {{ include "identityhub.fullname" . }}-logging-config
             items:
               - key: "logging.properties"
                 path: "logging.properties"

--- a/charts/tractusx-identityhub/templates/identityhub-config.yaml
+++ b/charts/tractusx-identityhub/templates/identityhub-config.yaml
@@ -26,7 +26,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "identityhub-config"
+  name: {{ include "identityhub.fullname" . }}-config
   namespace: {{ .Release.Namespace | default "default" | quote }}
   labels:
     {{- include "identityhub.labels" . | nindent 4 }}

--- a/charts/tractusx-identityhub/templates/identityhub-config.yaml
+++ b/charts/tractusx-identityhub/templates/identityhub-config.yaml
@@ -1,4 +1,5 @@
 #################################################################################
+  #  Copyright (c) 2026 LKS Next
   #  Copyright (c) 2025 Cofinity-X
   #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #

--- a/charts/tractusx-identityhub/templates/identityhub-datasource-config.yaml
+++ b/charts/tractusx-identityhub/templates/identityhub-datasource-config.yaml
@@ -26,7 +26,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "identityhub-datasource-config"
+  name: {{ include "identityhub.fullname" . }}-datasource-config
   namespace: {{ .Release.Namespace | default "default" | quote }}
   labels:
     {{- include "identityhub.labels" . | nindent 4 }}

--- a/charts/tractusx-identityhub/templates/identityhub-logging-config.yaml
+++ b/charts/tractusx-identityhub/templates/identityhub-logging-config.yaml
@@ -1,5 +1,4 @@
 #################################################################################
-  #  Copyright (c) 2025 Cofinity-X
   #  Copyright (c) 2025 LKS Next
   #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
@@ -24,7 +23,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "identityhub.fullname" . }}
+  name: {{ include "identityhub.fullname" . }}-logging-config
   namespace: {{ .Release.Namespace | default "default" | quote }}
   labels:
     {{- include "identityhub.labels" . | nindent 4 }}

--- a/charts/tractusx-identityhub/values.yaml
+++ b/charts/tractusx-identityhub/values.yaml
@@ -176,7 +176,9 @@ identityhub:
   #  - second-secret
 
   # [Kubernetes ConfigMap Resource](https://kubernetes.io/docs/concepts/configuration/configmap/) names to load environment variables from
-  envConfigMapNames: ["identityhub-config", "identityhub-datasource-config"]
+  # Note: The chart automatically includes the built-in ConfigMaps (config and datasource-config) with dynamic names based on the release name.
+  # This array is for additional custom ConfigMaps only.
+  envConfigMapNames: []
   #  - first-config-map
   #  - second-config-map
 

--- a/charts/tractusx-issuerservice-memory/Chart.yaml
+++ b/charts/tractusx-issuerservice-memory/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.2.0
+version: v0.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/tractusx-issuerservice-memory/templates/deployment.yaml
+++ b/charts/tractusx-issuerservice-memory/templates/deployment.yaml
@@ -157,8 +157,10 @@ spec:
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
           {{- end }}
-          {{- if and (or .Values.issuerservice.envSecretNames .Values.issuerservice.envConfigMapNames) (or (gt (len .Values.issuerservice.envSecretNames) 0) (gt (len .Values.issuerservice.envConfigMapNames) 0)) }}
           envFrom:
+            - configMapRef:
+                name: {{ include "issuerservice.fullname" . }}-config
+          {{- if and (or .Values.issuerservice.envSecretNames .Values.issuerservice.envConfigMapNames) (or (gt (len .Values.issuerservice.envSecretNames) 0) (gt (len .Values.issuerservice.envConfigMapNames) 0)) }}
           {{- range $value := .Values.issuerservice.envSecretNames }}
             - secretRef:
                 name: {{ $value | quote }}
@@ -176,16 +178,16 @@ spec:
             {{- end }}
             - name: "tmp"
               mountPath: "/tmp"
-            - name: configuration
+            - name: logging-config
               mountPath: /app/logging.properties
               subPath: logging.properties
             - name: logs
               mountPath: {{ .Values.issuerservice.logging.path }}
 
       volumes:
-        - name: "configuration"
+        - name: "logging-config"
           configMap:
-            name: {{ include "issuerservice.fullname" . }}
+            name: {{ include "issuerservice.fullname" . }}-logging-config
             items:
               - key: "logging.properties"
                 path: "logging.properties"

--- a/charts/tractusx-issuerservice-memory/templates/issuerservice-config.yaml
+++ b/charts/tractusx-issuerservice-memory/templates/issuerservice-config.yaml
@@ -27,7 +27,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "issuerservice-config"
+  name: {{ include "issuerservice.fullname" . }}-config
   namespace: {{ .Release.Namespace | default "default" | quote }}
   labels:
     {{- include "issuerservice.labels" . | nindent 4 }}

--- a/charts/tractusx-issuerservice-memory/templates/issuerservice-logging-config.yaml
+++ b/charts/tractusx-issuerservice-memory/templates/issuerservice-logging-config.yaml
@@ -1,5 +1,4 @@
 #################################################################################
-  #  Copyright (c) 2025 Cofinity-X
   #  Copyright (c) 2025 LKS Next
   #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
@@ -24,7 +23,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "issuerservice.fullname" . }}
+  name: {{ include "issuerservice.fullname" . }}-logging-config
   namespace: {{ .Release.Namespace | default "default" | quote }}
   labels:
     {{- include "issuerservice.labels" . | nindent 4 }}

--- a/charts/tractusx-issuerservice-memory/values.yaml
+++ b/charts/tractusx-issuerservice-memory/values.yaml
@@ -170,7 +170,9 @@ issuerservice:
   #  - second-secret
 
   # [Kubernetes ConfigMap Resource](https://kubernetes.io/docs/concepts/configuration/configmap/) names to load environment variables from
-  envConfigMapNames: ["issuerservice-config"]
+  # Note: The chart automatically includes the built-in ConfigMap (config) with dynamic name based on the release name.
+  # This array is for additional custom ConfigMaps only.
+  envConfigMapNames: []
   #  - first-config-map
   #  - second-config-map
 

--- a/charts/tractusx-issuerservice/Chart.yaml
+++ b/charts/tractusx-issuerservice/Chart.yaml
@@ -36,7 +36,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.2.0
+version: v0.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/tractusx-issuerservice/templates/deployment.yaml
+++ b/charts/tractusx-issuerservice/templates/deployment.yaml
@@ -157,8 +157,12 @@ spec:
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
           {{- end }}
-          {{- if and (or .Values.issuerservice.envSecretNames .Values.issuerservice.envConfigMapNames) (or (gt (len .Values.issuerservice.envSecretNames) 0) (gt (len .Values.issuerservice.envConfigMapNames) 0)) }}
           envFrom:
+            - configMapRef:
+                name: {{ include "issuerservice.fullname" . }}-config
+            - configMapRef:
+                name: {{ include "issuerservice.fullname" . }}-datasource-config
+          {{- if and (or .Values.issuerservice.envSecretNames .Values.issuerservice.envConfigMapNames) (or (gt (len .Values.issuerservice.envSecretNames) 0) (gt (len .Values.issuerservice.envConfigMapNames) 0)) }}
           {{- range $value := .Values.issuerservice.envSecretNames }}
             - secretRef:
                 name: {{ $value | quote }}
@@ -176,15 +180,15 @@ spec:
             {{- end }}
             - name: "tmp"
               mountPath: "/tmp"
-            - name: configuration
+            - name: logging-config
               mountPath: /app/logging.properties
               subPath: logging.properties
             - name: logs
               mountPath: {{ .Values.issuerservice.logging.path }}
       volumes:
-        - name: "configuration"
+        - name: "logging-config"
           configMap:
-            name: {{ include "issuerservice.fullname" . }}
+            name: {{ include "issuerservice.fullname" . }}-logging-config
             items:
               - key: "logging.properties"
                 path: "logging.properties"

--- a/charts/tractusx-issuerservice/templates/issuerservice-config.yaml
+++ b/charts/tractusx-issuerservice/templates/issuerservice-config.yaml
@@ -27,7 +27,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "issuerservice-config"
+  name: {{ include "issuerservice.fullname" . }}-config
   namespace: {{ .Release.Namespace | default "default" | quote }}
   labels:
     {{- include "issuerservice.labels" . | nindent 4 }}

--- a/charts/tractusx-issuerservice/templates/issuerservice-datasource-config.yaml
+++ b/charts/tractusx-issuerservice/templates/issuerservice-datasource-config.yaml
@@ -27,7 +27,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "issuerservice-datasource-config"
+  name: {{ include "issuerservice.fullname" . }}-datasource-config
   namespace: {{ .Release.Namespace | default "default" | quote }}
   labels:
     {{- include "issuerservice.labels" . | nindent 4 }}

--- a/charts/tractusx-issuerservice/templates/issuerservice-logging-config.yaml
+++ b/charts/tractusx-issuerservice/templates/issuerservice-logging-config.yaml
@@ -1,5 +1,4 @@
 #################################################################################
-  #  Copyright (c) 2025 Cofinity-X
   #  Copyright (c) 2025 LKS Next
   #  Copyright (c) 2025 Contributors to the Eclipse Foundation
   #
@@ -24,7 +23,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "issuerservice.fullname" . }}
+  name: {{ include "issuerservice.fullname" . }}-logging-config
   namespace: {{ .Release.Namespace | default "default" | quote }}
   labels:
     {{- include "issuerservice.labels" . | nindent 4 }}

--- a/charts/tractusx-issuerservice/values.yaml
+++ b/charts/tractusx-issuerservice/values.yaml
@@ -177,7 +177,9 @@ issuerservice:
   #  - second-secret
 
   # [Kubernetes ConfigMap Resource](https://kubernetes.io/docs/concepts/configuration/configmap/) names to load environment variables from
-  envConfigMapNames: ["issuerservice-config", "issuerservice-datasource-config"]
+  # Note: The chart automatically includes the built-in ConfigMaps (config and datasource-config) with dynamic names based on the release name.
+  # This array is for additional custom ConfigMaps only.
+  envConfigMapNames: []
   #  - first-config-map
   #  - second-config-map
 


### PR DESCRIPTION
## WHAT
Update the configmaps so they are deployed with different names in case of multiple instances of the same chart.

## WHY
Scalable and being able to deploy multiple instances of the same chart with different configuration

## FURTHER NOTES

This PR is necessary for Umbrella data-exchange attempt with two identityhubs

Closes #257 
