### PR TITLE
feat: make VC type aliases for scope evaluation configurable

### DIFF
--- a/runtimes/identityhub-memory/src/main/java/org/eclipse/edc/identityhub/demo/IdentityHubExtension.java
+++ b/runtimes/identityhub-memory/src/main/java/org/eclipse/edc/identityhub/demo/IdentityHubExtension.java
@@ -24,15 +24,53 @@ package org.eclipse.edc.identityhub.demo;
 import org.eclipse.edc.identityhub.spi.transformation.ScopeToCriterionTransformer;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 
 @Extension("DCP Demo: Core Extension for IdentityHub")
 public class IdentityHubExtension implements ServiceExtension {
 
+    @Setting(
+            key = "tx.identityhub.scope.aliases",
+            value = "Comma-separated list of accepted credential scope aliases for presentation queries.",
+            defaultValue = TxScopeToCriterionTransformer.DEFAULT_ALIAS_LITERAL
+    )
+    public static final String TX_SCOPE_ALIASES = "tx.identityhub.scope.aliases";
+
+    private Set<String> allowedScopeAliases = Set.of(TxScopeToCriterionTransformer.DEFAULT_ALIAS_LITERAL);
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var configuredAliases = context.getSetting(TX_SCOPE_ALIASES, TxScopeToCriterionTransformer.DEFAULT_ALIAS_LITERAL);
+        allowedScopeAliases = parseAliases(configuredAliases);
+    }
+
     @Provider
     public ScopeToCriterionTransformer createScopeTransformer() {
-        return new TxScopeToCriterionTransformer();
+        return new TxScopeToCriterionTransformer(allowedScopeAliases);
+    }
+
+    static Set<String> parseAliases(String configuredAliases) {
+        var aliases = Arrays.stream(Objects.requireNonNullElse(configuredAliases, "").split(","))
+                .map(String::trim)
+                .filter(alias -> !alias.isBlank())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        if (aliases.isEmpty()) {
+            throw new EdcException("At least one scope alias must be configured for " + TX_SCOPE_ALIASES);
+        }
+
+        return Collections.unmodifiableSet(aliases);
     }
 
 }

--- a/runtimes/identityhub-memory/src/main/java/org/eclipse/edc/identityhub/demo/TxScopeToCriterionTransformer.java
+++ b/runtimes/identityhub-memory/src/main/java/org/eclipse/edc/identityhub/demo/TxScopeToCriterionTransformer.java
@@ -25,7 +25,12 @@ import org.eclipse.edc.identityhub.spi.transformation.ScopeToCriterionTransforme
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.result.Result;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.eclipse.edc.spi.result.Result.failure;
 import static org.eclipse.edc.spi.result.Result.success;
@@ -37,10 +42,31 @@ import static org.eclipse.edc.spi.result.Result.success;
 public class TxScopeToCriterionTransformer implements ScopeToCriterionTransformer {
 
     public static final String TYPE_OPERAND = "verifiableCredential.credential.type";
-    public static final String ALIAS_LITERAL = "org.eclipse.tractusx.vc.type";
+    public static final String DEFAULT_ALIAS_LITERAL = "org.eclipse.tractusx.vc.type";
+    public static final String ALIAS_LITERAL = DEFAULT_ALIAS_LITERAL;
     public static final String CONTAINS_OPERATOR = "contains";
     private static final String SCOPE_SEPARATOR = ":";
+    private final Set<String> allowedAliases;
+    private final String allowedAliasesDescription;
     private final List<String> allowedOperations = List.of("read", "*", "all");
+
+    public TxScopeToCriterionTransformer() {
+        this(Set.of(DEFAULT_ALIAS_LITERAL));
+    }
+
+    public TxScopeToCriterionTransformer(Set<String> allowedAliases) {
+        var sanitizedAliases = Objects.requireNonNull(allowedAliases, "allowedAliases").stream()
+                .map(String::trim)
+                .filter(alias -> !alias.isBlank())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        if (sanitizedAliases.isEmpty()) {
+            throw new IllegalArgumentException("allowedAliases cannot be empty");
+        }
+
+        this.allowedAliases = Collections.unmodifiableSet(sanitizedAliases);
+        allowedAliasesDescription = String.join(", ", sanitizedAliases);
+    }
 
     @Override
     public Result<Criterion> transform(String scope) {
@@ -59,8 +85,8 @@ public class TxScopeToCriterionTransformer implements ScopeToCriterionTransforme
         if (tokens.length != 3) {
             return failure("Scope string has invalid format.");
         }
-        if (!ALIAS_LITERAL.equalsIgnoreCase(tokens[0])) {
-            return failure("Scope alias MUST be %s but was %s".formatted(ALIAS_LITERAL, tokens[0]));
+        if (allowedAliases.stream().noneMatch(alias -> alias.equalsIgnoreCase(tokens[0]))) {
+            return failure("Scope alias MUST be one of %s but was %s".formatted(allowedAliasesDescription, tokens[0]));
         }
         if (!allowedOperations.contains(tokens[2])) {
             return failure("Invalid scope operation: " + tokens[2]);

--- a/runtimes/identityhub/src/main/java/org/eclipse/edc/identityhub/demo/IdentityHubExtension.java
+++ b/runtimes/identityhub/src/main/java/org/eclipse/edc/identityhub/demo/IdentityHubExtension.java
@@ -24,15 +24,53 @@ package org.eclipse.edc.identityhub.demo;
 import org.eclipse.edc.identityhub.spi.transformation.ScopeToCriterionTransformer;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 
 @Extension("DCP Demo: Core Extension for IdentityHub")
 public class IdentityHubExtension implements ServiceExtension {
 
+    @Setting(
+            key = "tx.identityhub.scope.aliases",
+            value = "Comma-separated list of accepted credential scope aliases for presentation queries.",
+            defaultValue = TxScopeToCriterionTransformer.DEFAULT_ALIAS_LITERAL
+    )
+    public static final String TX_SCOPE_ALIASES = "tx.identityhub.scope.aliases";
+
+    private Set<String> allowedScopeAliases = Set.of(TxScopeToCriterionTransformer.DEFAULT_ALIAS_LITERAL);
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var configuredAliases = context.getSetting(TX_SCOPE_ALIASES, TxScopeToCriterionTransformer.DEFAULT_ALIAS_LITERAL);
+        allowedScopeAliases = parseAliases(configuredAliases);
+    }
+
     @Provider
     public ScopeToCriterionTransformer createScopeTransformer() {
-        return new TxScopeToCriterionTransformer();
+        return new TxScopeToCriterionTransformer(allowedScopeAliases);
+    }
+
+    static Set<String> parseAliases(String configuredAliases) {
+        var aliases = Arrays.stream(Objects.requireNonNullElse(configuredAliases, "").split(","))
+                .map(String::trim)
+                .filter(alias -> !alias.isBlank())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        if (aliases.isEmpty()) {
+            throw new EdcException("At least one scope alias must be configured for " + TX_SCOPE_ALIASES);
+        }
+
+        return Collections.unmodifiableSet(aliases);
     }
 
 }

--- a/runtimes/identityhub/src/main/java/org/eclipse/edc/identityhub/demo/TxScopeToCriterionTransformer.java
+++ b/runtimes/identityhub/src/main/java/org/eclipse/edc/identityhub/demo/TxScopeToCriterionTransformer.java
@@ -25,7 +25,12 @@ import org.eclipse.edc.identityhub.spi.transformation.ScopeToCriterionTransforme
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.result.Result;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.eclipse.edc.spi.result.Result.failure;
 import static org.eclipse.edc.spi.result.Result.success;
@@ -37,10 +42,31 @@ import static org.eclipse.edc.spi.result.Result.success;
 public class TxScopeToCriterionTransformer implements ScopeToCriterionTransformer {
 
     public static final String TYPE_OPERAND = "verifiableCredential.credential.type";
-    public static final String ALIAS_LITERAL = "org.eclipse.tractusx.vc.type";
+    public static final String DEFAULT_ALIAS_LITERAL = "org.eclipse.tractusx.vc.type";
+    public static final String ALIAS_LITERAL = DEFAULT_ALIAS_LITERAL;
     public static final String CONTAINS_OPERATOR = "contains";
     private static final String SCOPE_SEPARATOR = ":";
+    private final Set<String> allowedAliases;
+    private final String allowedAliasesDescription;
     private final List<String> allowedOperations = List.of("read", "*", "all");
+
+    public TxScopeToCriterionTransformer() {
+        this(Set.of(DEFAULT_ALIAS_LITERAL));
+    }
+
+    public TxScopeToCriterionTransformer(Set<String> allowedAliases) {
+        var sanitizedAliases = Objects.requireNonNull(allowedAliases, "allowedAliases").stream()
+                .map(String::trim)
+                .filter(alias -> !alias.isBlank())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        if (sanitizedAliases.isEmpty()) {
+            throw new IllegalArgumentException("allowedAliases cannot be empty");
+        }
+
+        this.allowedAliases = Collections.unmodifiableSet(sanitizedAliases);
+        allowedAliasesDescription = String.join(", ", sanitizedAliases);
+    }
 
     @Override
     public Result<Criterion> transform(String scope) {
@@ -59,8 +85,8 @@ public class TxScopeToCriterionTransformer implements ScopeToCriterionTransforme
         if (tokens.length != 3) {
             return failure("Scope string has invalid format.");
         }
-        if (!ALIAS_LITERAL.equalsIgnoreCase(tokens[0])) {
-            return failure("Scope alias MUST be %s but was %s".formatted(ALIAS_LITERAL, tokens[0]));
+        if (allowedAliases.stream().noneMatch(alias -> alias.equalsIgnoreCase(tokens[0]))) {
+            return failure("Scope alias MUST be one of %s but was %s".formatted(allowedAliasesDescription, tokens[0]));
         }
         if (!allowedOperations.contains(tokens[2])) {
             return failure("Invalid scope operation: " + tokens[2]);

--- a/runtimes/identityhub/src/test/java/org/eclipse/edc/identityhub/demo/IdentityHubExtensionTest.java
+++ b/runtimes/identityhub/src/test/java/org/eclipse/edc/identityhub/demo/IdentityHubExtensionTest.java
@@ -1,0 +1,60 @@
+/*
+ *   Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ *   See the NOTICE file(s) distributed with this work for additional
+ *   information regarding copyright ownership.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Apache License, Version 2.0 which is available at
+ *   https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *   License for the specific language governing permissions and limitations
+ *   under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.eclipse.edc.identityhub.demo;
+
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class IdentityHubExtensionTest {
+
+    @Test
+    void initialize_usesConfiguredAliases(ServiceExtensionContext context) {
+        when(context.getSetting(eq(IdentityHubExtension.TX_SCOPE_ALIASES), eq(TxScopeToCriterionTransformer.DEFAULT_ALIAS_LITERAL)))
+                .thenReturn("org.eclipse.tractusx.vc.type, org.dataspacex.vc.type");
+
+        IdentityHubExtension extension = new IdentityHubExtension();
+        extension.initialize(context);
+
+        Result<Criterion> result = extension.createScopeTransformer().transform("org.dataspacex.vc.type:MembershipCredential:read");
+        assertTrue(result.succeeded());
+    }
+
+    @Test
+    void initialize_failsWhenAliasesAreBlank(ServiceExtensionContext context) {
+        when(context.getSetting(eq(IdentityHubExtension.TX_SCOPE_ALIASES), eq(TxScopeToCriterionTransformer.DEFAULT_ALIAS_LITERAL)))
+                .thenReturn(" , ");
+
+        IdentityHubExtension extension = new IdentityHubExtension();
+
+        assertThrows(EdcException.class, () -> extension.initialize(context));
+    }
+}

--- a/runtimes/identityhub/src/test/java/org/eclipse/edc/identityhub/demo/TxScopeToCriterionTransformerTest.java
+++ b/runtimes/identityhub/src/test/java/org/eclipse/edc/identityhub/demo/TxScopeToCriterionTransformerTest.java
@@ -1,0 +1,54 @@
+/*
+ *   Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ *   See the NOTICE file(s) distributed with this work for additional
+ *   information regarding copyright ownership.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Apache License, Version 2.0 which is available at
+ *   https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *   License for the specific language governing permissions and limitations
+ *   under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.eclipse.edc.identityhub.demo;
+
+import org.eclipse.edc.identityhub.spi.transformation.ScopeToCriterionTransformer;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.result.Result;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TxScopeToCriterionTransformerTest {
+
+    @Test
+    void transform_acceptsConfiguredAlias() {
+        ScopeToCriterionTransformer transformer = new TxScopeToCriterionTransformer(Set.of("org.eclipse.tractusx.vc.type", "org.dataspacex.vc.type"));
+
+        Result<Criterion> result = transformer.transform("org.dataspacex.vc.type:MembershipCredential:read");
+
+        assertTrue(result.succeeded());
+        assertNotNull(result.getContent());
+    }
+
+    @Test
+    void transform_rejectsUnsupportedAlias() {
+        ScopeToCriterionTransformer transformer = new TxScopeToCriterionTransformer();
+
+        Result<Criterion> result = transformer.transform("org.dataspacex.vc.type:MembershipCredential:read");
+
+        assertTrue(result.failed());
+        assertTrue(result.getFailureDetail().contains(TxScopeToCriterionTransformer.DEFAULT_ALIAS_LITERAL));
+    }
+}


### PR DESCRIPTION
## WHAT

It would be helpful if IdentityHub could make the VC type/scope alias used for VC-based access evaluation configurable.

Currently, the implementation appears to expect alias `org.eclipse.tractusx.vc.type`, while in Factory-X identifier `org.factoryx.vc.type` is used. Supporting configuration here would allow adopters like us to work with IdentityHub more easily while keeping the default behavior in place.

## WHY

We are currently trying to use Tractus-X IdentityHub for our verifiable credential setup in Factory-X.

The main obstacle seems to be not a difference in intent or behavior, but that a different alias is used for the same kind of credential lookup. A bit of configurability here would make integration easier for adopters in neighboring ecosystems and could help avoid local maintenance overhead for a relatively small compatibility gap.

## FURTHER NOTES

Allow one or more accepted aliases to be provided through configuration while the current alias stays as the default

That preserves the existing behavior for current users while offering a simple extension point for deployments with slightly different conventions.

Closes #278