### PR TITLE
chore: added IdentityHub and Data exchange e2e API bruno collection

### DIFF
--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/DCP Flow/Consumer STS Token.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/DCP Flow/Consumer STS Token.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Consumer STS Token
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{CONSUMER_IDHUB_STS_API}}/token
+  body: formUrlEncoded
+  auth: inherit
+}
+
+body:form-urlencoded {
+  grant_type: client_credentials
+  client_secret: {{CONSUMER_STS_SECRET}}
+  client_id: {{CONS_ID}}
+  audience: {{PROV_ID}}
+  bearer_access_scope: org.eclipse.tractusx.vc.type:MembershipCredential:read
+}
+
+script:post-response {
+  const atob = require("atob");
+  const accessToken = res.getBody().access_token.trim();
+  const parts = accessToken.split(".");
+  const payload = atob(parts[1]);
+  const payloadObject = JSON.parse(payload);
+  const internalToken = payloadObject.token.trim();
+  
+  bru.setEnvVar("cons_access_token", internalToken);
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/DCP Flow/Get Verifiable Presentation.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/DCP Flow/Get Verifiable Presentation.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Get Verifiable Presentation
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{CONSUMER_IDHUB_CREDS_API}}/v1/participants/{{B64_CONS_ID}}/presentations/query
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{prov_access_token}}
+}
+
+body:json {
+  {
+      "@context": [
+        "https://w3id.org/tractusx-trust/v0.8",
+        "https://identity.foundation/presentation-exchange/submission/v1"
+      ],
+      "type": "PresentationQueryMessage",
+      "presentationDefinition": null,
+      "scope": [
+        "org.eclipse.tractusx.vc.type:MembershipCredential:read"
+      ]
+  }
+}
+
+tests {
+  test("contains presentation", function(){
+    const presentation = res.getBody().presentation;
+    const isString = typeof(presentation) == "string";
+    const success = isString && presentation.split(".").length == 3;
+    expect(success == true);
+  })
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/DCP Flow/Provider STS Token.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/DCP Flow/Provider STS Token.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Provider STS Token
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{PROVIDER_IDHUB_STS_API}}/token
+  body: formUrlEncoded
+  auth: inherit
+}
+
+body:form-urlencoded {
+  grant_type: client_credentials
+  client_secret: {{PROVIDER_STS_SECRET}}
+  client_id: {{PROV_ID}}
+  audience: {{CONS_ID}}
+  token: {{cons_access_token}}
+}
+
+script:post-response {
+  const accessToken = res.getBody().access_token.trim();
+  
+  bru.setEnvVar("prov_access_token", accessToken);
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/DCP Flow/folder.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/DCP Flow/folder.bru
@@ -1,0 +1,34 @@
+meta {
+  name: DCP Flow
+  seq: 5
+}
+
+auth {
+  mode: inherit
+}
+
+docs {
+  This section is meant to show in principle, what happens during a DCP protocol validated interaction between two controlplanes. It also serves as a final test. If these requests do succeed, then we can be sure that all previous steps went well. 
+  
+  Let's assume that the consumer intends to obtain the DSP catolog from the provider. 
+  Then the consumer will request a self signed SI token from his own Identity-Hub's secure token service (STS), see the "Consumer Token" request. 
+  
+  In that request body, the consumer informs the STS about the intended audience and the credential type he wants to show to the other side. 
+  
+  In the request body, we should receive an access token in JWT format, the "consumer-access-token". 
+  
+  Please feel free to decode the "consumer-access-token" with a tool of your choice and observe that token's payload. You will find, that this payload itself contains another JWT inside the "token" claim. 
+  
+  The entire "consumer-access-token" will now be sent by the consumer-side-EDC to the provider-side-EDC via the "Authentication" header of a request to the according DSP-catolog request api endpoint. Since the "consumer-access-token" is signed with the consumer private key, the provider can now download the consumer's DID document, read the consumer's public key and use it to check that the JWT's signature is valid. 
+  
+  We are not doing the signature check here in this small simulation, so let's just assume that it turned out positive. 
+  
+  Now the provider wants to see, which credentials the consumer is going to show him. For that, he needs to retrieve it from the consumer's credential service. The URL can be found in the consumer's DID document. 
+  
+  But first, he needs to talk to his own secure token service (STS). So he is unwrapping the "token" claim and sending it to his own STS, see the "Post Request Script" of the "Consumer Token" request and the request body in the "Provider Token" request. 
+  
+  The response of the provider's STS will contain another access token, we are calling it "provider access token". This "provider access token" can now be attached as an "authorization" header to the provider's request to the consumer's credential service. 
+  
+  The response of the consumer credential service contains the verifiable presentation, which itself now contains the verfiable credential, which the trusted issuer initially handed out to the consumer. 
+  
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Activate Participant Context- Consumer.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Activate Participant Context- Consumer.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Activate Participant Context- Consumer
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{CONSUMER_IDHUB_ID_API}}/v1alpha/participants/{{B64_CONS_ID}}/state?isActive=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  isActive: true
+}
+
+headers {
+  x-api-key: {{CONSUMER_IH_APIKEY}}
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Add Vault Secret - EDC Consumer.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Add Vault Secret - EDC Consumer.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Add Vault Secret - EDC Consumer
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{CONSUMER_EDC_VAULT}}/v1/secret/data/consumersecret
+  body: json
+  auth: inherit
+}
+
+headers {
+  X-Vault-Token: {{VAULT_TOKEN}}
+}
+
+body:json {
+  {
+    "data": {
+      "content": "{{CONSUMER_STS_SECRET}}"
+    }
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Create Consumer Participant.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Create Consumer Participant.bru
@@ -1,0 +1,62 @@
+meta {
+  name: Create Consumer Participant
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{CONSUMER_IDHUB_ID_API}}/v1alpha/participants
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{CONSUMER_IH_APIKEY}}
+}
+
+body:json {
+  {
+    "roles": ["ROLE_ADMIN", "admin"],
+    "serviceEndpoints": [
+      {
+        "id": "ConsumerCredentialService-ID",
+        "type": "CredentialService",
+        "serviceEndpoint": "{{CONSUMER_IDHUB_CREDS_API}}/v1/participants/{{B64_CONS_ID}}"
+      }
+    ],
+    "active": true,
+    "participantContextId": "{{CONS_ID}}",
+    "participantId": "{{CONS_ID}}",
+    "did": "{{CONS_ID}}",
+    "key": {
+      "keyId": "{{CONS_ID}}#key-1",
+      "privateKeyAlias": "{{CONS_ID}}-alias",
+      "keyGeneratorParams": {
+        "algorithm": "Ec",
+        "curve": "secp256r1"
+      }
+    }
+  }
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  const cons_id = bru.getEnvVar("CONS_ID");
+  bru.setEnvVar("B64_CONS_ID", btoa(cons_id));
+}
+
+script:post-response {
+  const apiKey = res.getBody().apiKey.trim();
+  if (apiKey) {
+    bru.setEnvVar("CONSUMER_IH_APIKEY", apiKey);
+  }
+  const stsSecret = res.getBody().clientSecret.trim();
+  if (stsSecret) {
+    bru.setEnvVar("CONSUMER_STS_SECRET", stsSecret)
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Delete Consumer Participant.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Delete Consumer Participant.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Delete Consumer Participant
+  type: http
+  seq: 9
+}
+
+delete {
+  url: {{CONSUMER_IDHUB_ID_API}}/v1alpha/participants/{{B64_CONS_ID}}
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{CONSUMER_IH_APIKEY}}
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  const prov_id = bru.getEnvVar("PROV_ID");
+  bru.setEnvVar("B64_PROV_ID", btoa(prov_id));
+}
+
+script:post-response {
+  const apiKey = res.getBody().apiKey.trim();
+  if (apiKey) {
+    bru.setEnvVar("PROVIDER_IH_APIKEY", apiKey);
+  }
+  const stsSecret = res.getBody().clientSecret.trim();
+  if (stsSecret) {
+    bru.setEnvVar("PROVIDER_STS_SECRET", stsSecret)
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Get Consumer DID Doc.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Get Consumer DID Doc.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get Consumer DID Doc
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{CONSUMER_IDHUB_DID_API}}/consumer
+  body: none
+  auth: inherit
+}
+
+headers {
+  Host: <CONSUMER_IDHUB_HOSTNAME>
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Get Consumer VC.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Get Consumer VC.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Get Consumer VC
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{CONSUMER_IDHUB_ID_API}}/v1alpha/participants/{{B64_CONS_ID}}/credentials
+  body: json
+  auth: none
+}
+
+headers {
+  x-api-key: {{CONSUMER_IH_APIKEY}}
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  const cons_id = bru.getEnvVar("PROV_ID");
+  bru.setEnvVar("B64_CONS_ID", btoa(cons_id));
+  
+  req.setHeader("x-api-key", bru.getEnvVar("CONSUMER_IH_APIKEY"));
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Request Consumer Credential.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Request Consumer Credential.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Request Consumer Credential
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{CONSUMER_IDHUB_ID_API}}/v1alpha/participants/{{B64_CONS_ID}}/credentials/request
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "issuerDid": "{{ISS_ID}}",
+    "holderPid": "{{ISS_ID}}",
+    "credentials": [
+      {
+        "format": "VC1_0_JWT",
+        "type": "MembershipCredential",
+        "id": "tx-membershipCredential"
+      }
+    ]
+  }
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  const cons_id = bru.getEnvVar("CONS_ID");
+  bru.setEnvVar("B64_CONS_ID", btoa(cons_id));
+  req.setHeader("x-api-key", bru.getEnvVar("CONSUMER_IH_APIKEY"));
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Verify Activation - Consumer Participant.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Verify Activation - Consumer Participant.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Verify Activation - Consumer Participant
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{CONSUMER_IDHUB_ID_API}}/v1alpha/participants/{{B64_CONS_ID}}
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{CONSUMER_IH_APIKEY}}
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  const cons_id = bru.getEnvVar("CONS_ID");
+  bru.setEnvVar("B64_CONS_ID", btoa(cons_id));
+}
+
+script:post-response {
+  const apiKey = res.getBody().apiKey.trim();
+  if (apiKey) {
+    bru.setEnvVar("CONSUMER_IH_APIKEY", apiKey);
+  }
+  const stsSecret = res.getBody().clientSecret.trim();
+  if (stsSecret) {
+    bru.setEnvVar("CONSUMER_STS_SECRET", stsSecret)
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Verify Vault Secret - EDC Consumer.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/Verify Vault Secret - EDC Consumer.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Verify Vault Secret - EDC Consumer
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{CONSUMER_EDC_VAULT}}/v1/secret/data/consumersecret
+  body: none
+  auth: inherit
+}
+
+headers {
+  X-Vault-Token: {{VAULT_TOKEN}}
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/folder.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Consumer/folder.bru
@@ -1,0 +1,13 @@
+meta {
+  name: Prepare Consumer
+  seq: 2
+}
+
+auth {
+  mode: inherit
+}
+
+docs {
+  The requests in this folder are necessary for creating the identity of the consumer participant. 
+  We are doing an initial registration at the identity hub. Then we take a look at the created DID document. Then we trigger a credential request toward the trusted issuer. And also, we are storing the STS secret that the identity hub gave us, at the vault. 
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/Activate Participant Context.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/Activate Participant Context.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Activate Participant Context
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{ISSUER_ID_API}}/v1alpha/participants/{{B64_ISS_ID}}/state?isActive=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  isActive: true
+}
+
+headers {
+  x-api-key: {{ISSUER_APIKEY}}
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/Add Consumer Holder.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/Add Consumer Holder.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Add Consumer Holder
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{ISSUER_ISS_API}}/v1alpha/participants/{{B64_ISS_ID}}/holders
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{ISSUER_APIKEY}}
+}
+
+body:json {
+  {
+    "holderId" : "{{CONS_ID}}", 
+    "did" : "{{CONS_ID}}", 
+    "name" : "{{CONS_ID}}"
+  }
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  const iss_id = bru.getEnvVar("ISS_ID");
+  bru.setEnvVar("B64_ISS_ID", btoa(iss_id));
+  
+  const cons_id = bru.getEnvVar("CONS_ID");
+  bru.setEnvVar("B64_CONS_ID", btoa(cons_id));
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/Add Provider Holder.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/Add Provider Holder.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Add Provider Holder
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{ISSUER_ISS_API}}/v1alpha/participants/{{B64_ISS_ID}}/holders
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{ISSUER_APIKEY}}
+}
+
+body:json {
+  {
+    "holderId" : "{{PROV_ID}}", 
+    "did" : "{{PROV_ID}}",  
+    "name" : "{{PROV_ID}}"
+  }
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  const iss_id = bru.getEnvVar("ISS_ID");
+  bru.setEnvVar("B64_ISS_ID", btoa(iss_id));
+  const prov_id = bru.getEnvVar("PROV_ID");
+  bru.setEnvVar("B64_PROV_ID", btoa(prov_id));
+  
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/Create Attestation.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/Create Attestation.bru
@@ -1,0 +1,38 @@
+meta {
+  name: Create Attestation
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{ISSUER_ISS_API}}/v1alpha/participants/{{B64_ISS_ID}}/attestations
+  body: json
+  auth: none
+}
+
+headers {
+  ~x-api-key: {{ISSUER_APIKEY}}
+}
+
+body:json {
+  {
+    "id": "attestation-id",
+    "attestationType": "database",
+    "configuration": {
+        "dataSourceName": "holder",
+        "tableName": "holders"
+      }
+  }
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  const iss_id = bru.getEnvVar("ISS_ID");
+  bru.setEnvVar("B64_ISS_ID", btoa(iss_id));
+  req.setHeader("x-api-key", bru.getEnvVar("ISSUER_APIKEY"));
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/Create Credential Definition.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/Create Credential Definition.bru
@@ -1,0 +1,50 @@
+meta {
+  name: Create Credential Definition
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{ISSUER_ISS_API}}/v1alpha/participants/{{B64_ISS_ID}}/credentialdefinitions
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "attestations": [
+      "attestation-id"
+    ],
+    "credentialType": "MembershipCredential",
+    "format": "VC1_0_JWT",
+    "id": "tx-membershipCredential",
+    "jsonSchema": "{}",
+    "jsonSchemaUrl": "https://raw.githubusercontent.com/eclipse-tractusx/tractusx-profiles/main/cx/credentials/membership.credential.schema.json",
+    "mappings": [
+      {
+        "input": "did",
+        "output": "credentialSubject.id",
+        "required": true
+      },
+      {
+        "input": "holder_id",
+        "output": "credentialSubject.holderIdentifier",
+        "required": true
+      }
+    ],
+    "validity": 10000000000000
+  }
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  const iss_id = bru.getEnvVar("ISS_ID");
+  bru.setEnvVar("B64_ISS_ID", btoa(iss_id));
+  
+  req.setHeader("x-api-key", bru.getEnvVar("ISSUER_APIKEY"));
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/Create Issuer Participant.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/Create Issuer Participant.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Create Issuer Participant
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{ISSUER_ID_API}}/v1alpha/participants
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{ISSUER_APIKEY}}
+}
+
+body:json {
+  {
+    "roles": ["ROLE_ADMIN", "admin"],
+    "serviceEndpoints": [
+      {
+        "id": "Issuer-IssuerService", 
+        "type": "IssuerService", 
+        "serviceEndpoint": "{{ISSUER_ISSUANCE_API}}/v1alpha/participants/{{B64_ISS_ID}}"
+      }
+    ],
+    "active": true,
+    "participantContextId": "{{ISS_ID}}",
+    "participantId": "{{ISS_ID}}",
+    "did": "{{ISS_ID}}",
+    "key": {
+      "keyId": "{{ISS_ID}}#key-1",
+      "privateKeyAlias": "{{ISS_ID}}-alias",
+      "keyGeneratorParams": {
+        "algorithm": "Ec",
+        "curve": "secp256r1"
+      }
+    }
+  }
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  const iss_id = bru.getEnvVar("ISS_ID");
+  bru.setEnvVar("B64_ISS_ID", btoa(iss_id));
+}
+
+script:post-response {
+  const apiKey = res.getBody().apiKey.trim();
+  if (apiKey) {
+    bru.setEnvVar("ISSUER_APIKEY", apiKey);
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/Get Issuer DID Doc.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/Get Issuer DID Doc.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get Issuer DID Doc
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{ISSUER_DID_API}}/issuer
+  body: none
+  auth: inherit
+}
+
+headers {
+  Host: <ISSUER_HOSTNAME>
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/Verify Activation - Issuer Participant.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/Verify Activation - Issuer Participant.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Verify Activation - Issuer Participant
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{ISSUER_ID_API}}/v1alpha/participants/{{B64_ISS_ID}}
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{ISSUER_APIKEY}}
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  const iss_id = bru.getEnvVar("ISS_ID");
+  bru.setEnvVar("B64_ISS_ID", btoa(iss_id));
+}
+
+script:post-response {
+  const apiKey = res.getBody().apiKey.trim();
+  if (apiKey) {
+    bru.setEnvVar("ISSUER_APIKEY", apiKey);
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/folder.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Issuer/folder.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Prepare Issuer
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}
+
+docs {
+  This folder contains the initial steps for setting up our own dataspace. First, we need to define the participant that is universally trusted by all regular dataspace members, the so-called "trusted issuer". 
+  
+  First we register him under his own did:web id at the issuer service host. 
+  
+  Then we will announce the existence of other regular members. This is done in the "addXXXHolder" requests. 
+  
+  Then we have to tell to issuer participant that there shall be membership credentials, which can be handed out to the entities, which we had announced as holders. 
+  
+  Since the primary motivation for this collection is not to be a guide for handling the administration of data space issuers, the details of the "createAttestation" and "createCredentialDef" requests don't matter much at this point. It suffices to say that they are technically required to enable the credential issuance process. 
+  
+  
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Activate Participant Context- Provider.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Activate Participant Context- Provider.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Activate Participant Context- Provider
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{PROVIDER_IDHUB_ID_API}}/v1alpha/participants/{{B64_PROV_ID}}/state?isActive=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  isActive: true
+}
+
+headers {
+  x-api-key: {{PROVIDER_IH_APIKEY}}
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Add Vault Secret - EDC Provider.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Add Vault Secret - EDC Provider.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Add Vault Secret - EDC Provider
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{PROVIDER_EDC_VAULT}}/v1/secret/data/providersecret
+  body: json
+  auth: inherit
+}
+
+headers {
+  X-Vault-Token: {{VAULT_TOKEN}}
+}
+
+body:json {
+  {
+    "data": {
+      "content": "{{PROVIDER_STS_SECRET}}"
+    }
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Create Provider Participant.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Create Provider Participant.bru
@@ -1,0 +1,62 @@
+meta {
+  name: Create Provider Participant
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{PROVIDER_IDHUB_ID_API}}/v1alpha/participants
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{PROVIDER_IH_APIKEY}}
+}
+
+body:json {
+  {
+    "roles": ["ROLE_ADMIN", "admin"],
+    "serviceEndpoints": [
+      {
+        "id": "ProviderCredentialService-ID",
+        "type": "CredentialService",
+        "serviceEndpoint": "{{PROVIDER_IDHUB_CREDS_API}}/v1/participants/{{B64_PROV_ID}}"
+      }
+    ],
+    "active": true,
+    "participantContextId": "{{PROV_ID}}",
+    "participantId": "{{PROV_ID}}",
+    "did": "{{PROV_ID}}",
+    "key": {
+      "keyId": "{{PROV_ID}}#key-1",
+      "privateKeyAlias": "{{PROV_ID}}-alias",
+      "keyGeneratorParams": {
+        "algorithm": "Ec",
+        "curve": "secp256r1"
+      }
+    }
+  }
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  const prov_id = bru.getEnvVar("PROV_ID");
+  bru.setEnvVar("B64_PROV_ID", btoa(prov_id));
+}
+
+script:post-response {
+  const apiKey = res.getBody().apiKey.trim();
+  if (apiKey) {
+    bru.setEnvVar("PROVIDER_IH_APIKEY", apiKey);
+  }
+  const stsSecret = res.getBody().clientSecret.trim();
+  if (stsSecret) {
+    bru.setEnvVar("PROVIDER_STS_SECRET", stsSecret)
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Delete Provider Participant.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Delete Provider Participant.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Delete Provider Participant
+  type: http
+  seq: 9
+}
+
+delete {
+  url: {{PROVIDER_IDHUB_ID_API}}/v1alpha/participants/{{B64_PROV_ID}}
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{PROVIDER_IH_APIKEY}}
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  const prov_id = bru.getEnvVar("PROV_ID");
+  bru.setEnvVar("B64_PROV_ID", btoa(prov_id));
+}
+
+script:post-response {
+  const apiKey = res.getBody().apiKey.trim();
+  if (apiKey) {
+    bru.setEnvVar("PROVIDER_IH_APIKEY", apiKey);
+  }
+  const stsSecret = res.getBody().clientSecret.trim();
+  if (stsSecret) {
+    bru.setEnvVar("PROVIDER_STS_SECRET", stsSecret)
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Get Provider DID Doc.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Get Provider DID Doc.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get Provider DID Doc
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{PROVIDER_IDHUB_DID_API}}/provider
+  body: none
+  auth: inherit
+}
+
+headers {
+  Host: <PROVIDER_IDHUB_HOSTNAME>
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Get Provider VC.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Get Provider VC.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Get Provider VC
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{PROVIDER_IDHUB_ID_API}}/v1alpha/participants/{{B64_PROV_ID}}/credentials
+  body: json
+  auth: none
+}
+
+headers {
+  x-api-key: {{PROVIDER_IH_APIKEY}}
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  const prov_id = bru.getEnvVar("PROV_ID");
+  bru.setEnvVar("B64_PROV_ID", btoa(prov_id));
+  
+  req.setHeader("x-api-key", bru.getEnvVar("PROVIDER_IH_APIKEY"));
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Request Provider Credential.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Request Provider Credential.bru
@@ -1,0 +1,38 @@
+meta {
+  name: Request Provider Credential
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{PROVIDER_IDHUB_ID_API}}/v1alpha/participants/{{B64_PROV_ID}}/credentials/request
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "issuerDid": "{{ISS_ID}}",
+    "holderPid": "{{ISS_ID}}",
+    "credentials": [
+      {
+        "format": "VC1_0_JWT",
+        "type": "MembershipCredential",
+        "id": "tx-membershipCredential"
+      }
+    ]
+  }
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  const prov_id = bru.getEnvVar("PROV_ID");
+  bru.setEnvVar("B64_PROV_ID", btoa(prov_id));
+  
+  req.setHeader("x-api-key", bru.getEnvVar("PROVIDER_IH_APIKEY"));
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Verify Activation - Provider Participant.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Verify Activation - Provider Participant.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Verify Activation - Provider Participant
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{PROVIDER_IDHUB_ID_API}}/v1alpha/participants/{{B64_PROV_ID}}
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-api-key: {{PROVIDER_IH_APIKEY}}
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  const prov_id = bru.getEnvVar("PROV_ID");
+  bru.setEnvVar("B64_PROV_ID", btoa(prov_id));
+}
+
+script:post-response {
+  const apiKey = res.getBody().apiKey.trim();
+  if (apiKey) {
+    bru.setEnvVar("PROVIDER_IH_APIKEY", apiKey);
+  }
+  const stsSecret = res.getBody().clientSecret.trim();
+  if (stsSecret) {
+    bru.setEnvVar("PROVIDER_STS_SECRET", stsSecret)
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Verify Vault Secret - EDC Provider.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/Verify Vault Secret - EDC Provider.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Verify Vault Secret - EDC Provider
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{PROVIDER_EDC_VAULT}}/v1/secret/data/providersecret
+  body: none
+  auth: inherit
+}
+
+headers {
+  X-Vault-Token: {{VAULT_TOKEN}}
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/folder.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Prepare Provider/folder.bru
@@ -1,0 +1,13 @@
+meta {
+  name: Prepare Provider
+  seq: 3
+}
+
+auth {
+  mode: inherit
+}
+
+docs {
+  The requests in this folder are necessary for creating the identity of the provider participant. 
+  We are doing an initial registration at the identity hub. Then we take a look at the created DID document. Then we trigger a credential request toward the trusted issuer. And also, we are storing the STS secret that the identity hub gave us, at the vault. 
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Verify Credentials/Verify Consumer Credentials.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Verify Credentials/Verify Consumer Credentials.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Verify Consumer Credentials
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{CONSUMER_IDHUB_ID_API}}/v1alpha/credentials
+  body: none
+  auth: none
+}
+
+headers {
+  x-api-key: {{CONSUMER_IH_APIKEY}}
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Verify Credentials/Verify Provider Credentials.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Verify Credentials/Verify Provider Credentials.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Verify Provider Credentials
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{PROVIDER_IDHUB_ID_API}}/v1alpha/credentials
+  body: none
+  auth: none
+}
+
+headers {
+  x-api-key: {{PROVIDER_IH_APIKEY}}
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Verify Credentials/folder.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/Verify Credentials/folder.bru
@@ -1,0 +1,12 @@
+meta {
+  name: Verify Credentials
+  seq: 4
+}
+
+auth {
+  mode: inherit
+}
+
+docs {
+  Here we are taking a look at the credentials, that the trusted issuer created for the participants. 
+}

--- a/docs/api/bruno/Identity Hub e2e/01 Setup Identities/folder.bru
+++ b/docs/api/bruno/Identity Hub e2e/01 Setup Identities/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: 01 Setup Identities
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}

--- a/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Consumer/Get Data.bru
+++ b/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Consumer/Get Data.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get Data
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{PROVIDER_DATAPLANE_PUBLIC}}
+  body: none
+  auth: inherit
+}
+
+script:pre-request {
+  req.setHeader("Authorization", bru.getEnvVar("pullSecret"));
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Consumer/Get EDR.bru
+++ b/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Consumer/Get EDR.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Get EDR
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{CONSUMER_MANAGEMENT}}/v3/edrs/{{transferId}}/dataaddress
+  body: none
+  auth: apikey
+}
+
+headers {
+  Accept: application/json
+}
+
+auth:apikey {
+  key: X-Api-Key
+  value: password
+  placement: header
+}
+
+script:post-response {
+  const authToken = res.getBody().authorization; 
+  bru.setEnvVar("pullSecret", authToken);
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Consumer/Initiate Negotiation.bru
+++ b/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Consumer/Initiate Negotiation.bru
@@ -1,0 +1,53 @@
+meta {
+  name: Initiate Negotiation
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{CONSUMER_MANAGEMENT}}/v3/contractnegotiations
+  body: json
+  auth: apikey
+}
+
+headers {
+  Accept: application/json
+}
+
+auth:apikey {
+  key: X-Api-Key
+  value: {{CONSUMER_API_KEY}}
+  placement: header
+}
+
+body:json {
+  {
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+      "odrl": "http://www.w3.org/ns/odrl/2/"
+    },
+    "@type": "ContractRequest",
+    "counterPartyAddress": "{{PROVIDER_DSP}}",
+    "connectorId": "{{PROV_ID}}",
+    "protocol": "dataspace-protocol-http",
+    "policy": {
+      "@context": "http://www.w3.org/ns/odrl.jsonld",
+      "@id": "{{offerId}}",
+      "@type": "Offer",
+      "assigner": "{{PROV_ID}}",
+      "assignee": "{{CONS_ID}}",
+      "target": "assetId"
+    }
+  }
+}
+
+script:post-response {
+  var x = res.getBody()['@id'];
+  console.log("id " + x);
+  bru.setEnvVar("negotiation-id", res.getBody()['@id']);
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Consumer/Initiate Transfer Process.bru
+++ b/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Consumer/Initiate Transfer Process.bru
@@ -1,0 +1,41 @@
+meta {
+  name: Initiate Transfer Process
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{CONSUMER_MANAGEMENT}}/v3/transferprocesses
+  body: json
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-Api-Key
+  value: {{CONSUMER_API_KEY}}
+  placement: header
+}
+
+body:json {
+  {
+      "@context": {
+          "edc": "https://w3id.org/edc/v0.0.1/ns/"
+      },
+      "@type": "TransferRequestDto",
+      "protocol": "dataspace-protocol-http",
+      "contractId": "{{contractId}}",
+      "counterPartyAddress": "{{PROVIDER_DSP}}",
+      "connectorId": "{{PROV_ID}}",
+      "transferType": "HttpData-PULL"
+  }
+}
+
+script:post-response {
+  const transferId = res.getBody()['@id'];
+  bru.setEnvVar("transferId", transferId);
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Consumer/Query Catalog.bru
+++ b/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Consumer/Query Catalog.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Query Catalog
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{CONSUMER_MANAGEMENT}}/v3/catalog/request
+  body: json
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-Api-Key
+  value: {{CONSUMER_API_KEY}}
+  placement: header
+}
+
+body:json {
+  {
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+    },
+    "counterPartyAddress": "{{PROVIDER_DSP}}",
+    "counterPartyId": "{{PROV_ID}}",
+    "protocol": "dataspace-protocol-http"
+  
+  }
+}
+
+script:post-response {
+  const offerId = res.getBody()['dcat:dataset']['odrl:hasPolicy']['@id'];
+  
+  bru.setEnvVar("offerId", offerId);
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Consumer/Verify Negotiation Status.bru
+++ b/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Consumer/Verify Negotiation Status.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Verify Negotiation Status
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{CONSUMER_MANAGEMENT}}/v3/contractnegotiations/{{negotiation-id}}
+  body: none
+  auth: apikey
+}
+
+headers {
+  Accept: application/json
+}
+
+auth:apikey {
+  key: X-Api-Key
+  value: password
+  placement: header
+}
+
+script:post-response {
+  const contractId = res.getBody()['contractAgreementId']; 
+  bru.setEnvVar("contractId", contractId);
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Consumer/folder.bru
+++ b/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Consumer/folder.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Consumer
+  seq: 2
+}
+
+auth {
+  mode: inherit
+}
+
+docs {
+  Here, we are taking the role of the consumer participant. 
+  
+  First, we inspect the providers catalog. There we should find the asset, that was prepared in the previous stage. 
+  
+  Then we trigger a negotiation process, and check its (hopefully positive) outcome. 
+  
+  After that, we initiate a transfer process based on the previously negotiated contract. In the following step, we retrieve the authorization token, which the provider will give us. 
+  
+  And finally, we are using that token to get access to the data, that was placed inside the provider's asset. 
+}

--- a/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Provider/Create Asset.bru
+++ b/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Provider/Create Asset.bru
@@ -1,0 +1,45 @@
+meta {
+  name: Create Asset
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{PROVIDER_MANAGEMENT}}/v3/assets
+  body: json
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-Api-Key
+  value: {{PROVIDER_API_KEY}}
+  placement: header
+}
+
+body:json {
+  {
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+    },
+    "@id": "assetId",
+    "properties": {
+      "name": "product description",
+      "contenttype": "application/json"
+    },
+    "dataAddress": {
+      "type": "HttpData",
+      "name": "Test asset",
+      "baseUrl": "https://jsonplaceholder.typicode.com/users",
+      "proxyPath": "true", 
+      "proxyMethod": "true",
+      "proxyBody": "true", 
+      "authKey": "x-api-key", 
+      "authCode": "someAuthCode"
+    }
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Provider/Create Contract Definition.bru
+++ b/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Provider/Create Contract Definition.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Create Contract Definition
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{PROVIDER_MANAGEMENT}}/v3/contractdefinitions
+  body: json
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-Api-Key
+  value: {{PROVIDER_API_KEY}}
+  placement: header
+}
+
+body:json {
+  {
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+    },
+    "@id": "1",
+    "accessPolicyId": "aPolicy",
+    "contractPolicyId": "aPolicy",
+    "assetsSelector": []
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Provider/Create Policy.bru
+++ b/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Provider/Create Policy.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Create Policy
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{PROVIDER_MANAGEMENT}}/v3/policydefinitions
+  body: json
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-Api-Key
+  value: {{PROVIDER_API_KEY}}
+  placement: header
+}
+
+body:json {
+  {
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+      "odrl": "http://www.w3.org/ns/odrl/2/"
+    },
+    "@id": "aPolicy",
+    "policy": {
+      "@context": "http://www.w3.org/ns/odrl.jsonld",
+      "@type": "Set",
+      "permission": [],
+      "prohibition": [],
+      "obligation": []
+    }
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Provider/folder.bru
+++ b/docs/api/bruno/Identity Hub e2e/02 Data Exchange/Provider/folder.bru
@@ -1,0 +1,12 @@
+meta {
+  name: Provider
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}
+
+docs {
+  In this section we are creating a simple data asset on the provider side, i.e. we register an asset, create a policy- and a contract definition. 
+}

--- a/docs/api/bruno/Identity Hub e2e/02 Data Exchange/folder.bru
+++ b/docs/api/bruno/Identity Hub e2e/02 Data Exchange/folder.bru
@@ -1,0 +1,11 @@
+meta {
+  name: 02 Data Exchange
+}
+
+auth {
+  mode: inherit
+}
+
+docs {
+  This section showcases the typical negotiation and transfer flows between EDC connectors. 
+}

--- a/docs/api/bruno/Identity Hub e2e/bruno.json
+++ b/docs/api/bruno/Identity Hub e2e/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "Identity Hub e2e",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/docs/api/bruno/Identity Hub e2e/environments/local.bru
+++ b/docs/api/bruno/Identity Hub e2e/environments/local.bru
@@ -1,0 +1,38 @@
+vars {
+  ISSUER_DID_API: http://localhost:8083
+  ISSUER_ID_API: http://localhost:8087/api/identity
+  ISSUER_ISS_API: http://localhost:8086/api/admin
+  ISSUER_ISSUANCE_API: http://localhost:8082/api/issuance
+  CONSUMER_IDHUB_DID_API: http://localhost:8084
+  CONSUMER_IDHUB_ID_API: http://localhost:8082/api/identity
+  CONSUMER_IDHUB_STS_API: http://localhost:8087/api/sts
+  CONSUMER_IDHUB_CREDS_API: http://localhost:8083/api/credentials
+  PROVIDER_MANAGEMENT: http://dataprovider-controlplane:8081/management
+  CONSUMER_MANAGEMENT: http://dataconsumer-controlplane:8081/management
+  PROVIDER_DATAPLANE_PUBLIC: http://dataprovider-dataplane:8081/api/public
+  PROVIDER_IDHUB_DID_API: http://localhost:8084
+  PROVIDER_IDHUB_ID_API: http://localhost:8082/api/identity
+  PROVIDER_IDHUB_STS_API: http://localhost:8087/api/sts
+  PROVIDER_IDHUB_CREDS_API: http://localhost:8083/api/credentials
+  ISS_ID: did:web:issuerservice-issuance.example.com:issuer
+  CONS_ID: did:web:consumer-identityhub-presentation.example.com:consumer
+  PROV_ID: did:web:provider-identityhub-presentation.example.com:provider
+  B64_CONS_ID: ZGlkOndlYjpjb25zdW1lci1pZGVudGl0eWh1Yi1wcmVzZW50YXRpb24uZXhhbXBsZS5jb206Y29uc3VtZXI=
+  B64_PROV_ID: ZGlkOndlYjpwcm92aWRlci1pZGVudGl0eWh1Yi1wcmVzZW50YXRpb24uZXhhbXBsZS5jb206cHJvdmlkZXI=
+  B64_ISS_ID: ZGlkOndlYjppc3N1ZXJzZXJ2aWNlLWlzc3VhbmNlLmV4YW1wbGUuY29tOmlzc3Vlcg==
+  ISSUER_APIKEY: <ISSUER_API_KEY>
+  CONSUMER_IH_APIKEY: <CONSUMER_IH_API_KEY>
+  CONSUMER_STS_SECRET:
+  PROVIDER_IH_APIKEY: <PROVIDER_IH_API_KEY>
+  PROVIDER_STS_SECRET: 
+  cons_access_token: 
+  prov_access_token: 
+  CONSUMER_EDC_VAULT: http://localhost:8200
+  PROVIDER_EDC_VAULT: http://localhost:8201
+  VAULT_TOKEN: root
+  PROVIDER_API_KEY: TEST2
+  CONSUMER_API_KEY: TEST1
+  PROVIDER_CONTROLPLANE: http://dataprovider-controlplane
+  CONSUMER_CONTROLPLANE: http://dataconsumer-controlplane
+  PROVIDER_DSP: http://dataprovider-controlplane:8084/api/v1/dsp
+}


### PR DESCRIPTION
## WHAT

_Briefly describe what your PR changes, which features it adds/modifies._

### Added
- Added Bruno collection for End-to-End walkthough API testing in the localhost
   - Setup Identities (Includes setting up Issuer, Consumer and Provider IdentityHub services)
   - Data Exchange (Includes data exchange transactions based on the Identity services in step 1)

## WHY

_Briefly state why the change was necessary._
The API collection enables developers to walkthrough the Identity Hub APIs and perform data exchange using the Tractus-x connector.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

To consume the API collection, the following setup of services are required:
- Issuer Service
- Consumer IdentityHub
- Provider IdentityHub
- Consumer Connector
- Provider Connector


Closes # <-- _insert Issue number if one exists_
