### PR TITLE
fix: add idempotent issuanceprocess V0_0_3 to ensure `edc_lease` schema

### DIFF
--- a/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/store/postgresql/issuanceprocess/V0_0_3__Ensure_Lease_Schema.sql
+++ b/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/store/postgresql/issuanceprocess/V0_0_3__Ensure_Lease_Schema.sql
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2026 Technovative Solutions
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/store/postgresql/issuanceprocess/V0_0_3__Ensure_Lease_Schema.sql
+++ b/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/store/postgresql/issuanceprocess/V0_0_3__Ensure_Lease_Schema.sql
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Technovative Solutions
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+-- Fixes https://github.com/eclipse-tractusx/tractusx-identityhub/issues/289
+--
+-- The issuanceprocess V0_0_2 migration only dropped the FK + lease_id column on the
+-- issuance_process side and relied on the credentialrequest V0_0_2 migration in the
+-- same datasource to recreate edc_lease with the EDC 0.15.1 composite-PK schema.
+-- The issuerservice runtime does not deploy the credentialrequest store, so its
+-- edc_lease remained in the legacy (lease_id PK) shape, causing every state-machine
+-- tick to fail with: 'column l.resource_id does not exist'.
+--
+-- This migration is idempotent: it inspects information_schema and only recreates
+-- edc_lease when the legacy shape is detected. On databases where edc_lease already
+-- has the new composite-PK schema (e.g. identityhub, where credentialrequest V0_0_2
+-- handled the recreate), it is a no-op.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'edc_lease'
+          AND column_name = 'resource_id'
+    ) THEN
+        DROP INDEX IF EXISTS lease_lease_id_uindex;
+        DROP TABLE IF EXISTS edc_lease CASCADE;
+
+        CREATE TABLE edc_lease
+        (
+            leased_by      VARCHAR NOT NULL,
+            leased_at      BIGINT,
+            lease_duration INTEGER NOT NULL,
+            resource_id    VARCHAR NOT NULL,
+            resource_kind  VARCHAR NOT NULL,
+            PRIMARY KEY (resource_id, resource_kind)
+        );
+
+        COMMENT ON COLUMN edc_lease.leased_at IS 'posix timestamp of lease';
+        COMMENT ON COLUMN edc_lease.lease_duration IS 'duration of lease in milliseconds';
+    END IF;
+END
+$$;


### PR DESCRIPTION
**Fixes #289**

---

### Problem

After the EDC 0.15.1 lease-mechanism redesign, `edc_lease` changed from a single-column primary key (`lease_id`) to a composite primary key (`resource_id, resource_kind`).

The existing `issuanceprocess/V0_0_2` migration correctly drops the stale FK constraint and `lease_id` column from `edc_issuance_process`, but explicitly delegates the `edc_lease` table recreate to `credentialrequest/V0_0_2`, relying on both migration sets running in the same datasource.

**The issuerservice runtime does not deploy the `credentialrequest` store.** Its `edc_lease` table therefore remains in the legacy shape permanently. Every state-machine tick then fails with:

```
SEVERE  column l.resource_id does not exist
```

The service continues to report `isSystemHealthy: true` because health checks only verify extension registration, not SQL query execution. Issuance processes never advance.

---

### Root cause

`issuanceprocess/V0_0_2__Update_Lease_Schema.sql` contains this comment (and relies on it being true):

```sql
-- The shared edc_lease table is recreated by the credentialrequest V0_0_2 migration,
-- which runs against the same datasource.
```

This assumption holds for **identityhub** (which deploys both stores) but **not** for **issuerservice** (which deploys only `issuanceprocess`).

---

### Fix

Add `issuanceprocess/V0_0_3__Ensure_Lease_Schema.sql` — an idempotent migration that detects the legacy schema shape via `information_schema.columns` and recreates `edc_lease` with the composite-PK schema only when needed.

```sql
DO $$
BEGIN
    IF NOT EXISTS (
        SELECT 1
        FROM information_schema.columns
        WHERE table_name = 'edc_lease'
          AND column_name = 'resource_id'
    ) THEN
        DROP INDEX IF EXISTS lease_lease_id_uindex;
        DROP TABLE IF EXISTS edc_lease CASCADE;
        CREATE TABLE edc_lease (
            leased_by      VARCHAR NOT NULL,
            leased_at      BIGINT,
            lease_duration INTEGER NOT NULL,
            resource_id    VARCHAR NOT NULL,
            resource_kind  VARCHAR NOT NULL,
            PRIMARY KEY (resource_id, resource_kind)
        );
        ...
    END IF;
END
$$;
```

**Behaviour by deployment:**

| Runtime | Path taken |
|---|---|
| `issuerservice` (fresh DB) | `resource_id` column absent → DROP + CREATE with composite PK |
| `identityhub` (fresh DB) | `credentialrequest/V0_0_2` already created composite-PK table → no-op |
| Either runtime (upgrade from already-migrated DB) | `resource_id` column present → no-op |

`V0_0_2` is **not modified** — doing so would change the Flyway checksum and break every existing deployment.

---

### Why not modify V0_0_1 inline (like upstream eclipse-edc/IdentityHub)?

Upstream avoids this problem by defining `CREATE TABLE IF NOT EXISTS edc_lease` inline in each store's `*-schema.sql`. Aligning with that would require changing `V0_0_1`, which changes its Flyway checksum and breaks existing databases unless `validateOnMigrate=false` is set. That is a separate, larger change; this PR delivers the minimal safe fix.

---

### Verification

Tested against a clean database (volumes wiped) using the docker-compose SQL profile:

**issuerservice DB — before fix:**
```
Column   | Type    | ...
---------+---------+
lease_id | VARCHAR | PK
```
Error in logs: `SEVERE  column l.resource_id does not exist` (repeating every ~1 s)

**issuerservice DB — after fix:**
```
                       Table "public.edc_lease"
    Column     |       Type        | ...
---------------+-------------------+
 leased_by     | character varying |
 leased_at     | bigint            |
 lease_duration| integer           |
 resource_id   | character varying |
 resource_kind | character varying |
Indexes:
    "edc_lease_pkey" PRIMARY KEY, btree (resource_id, resource_kind)
```

```
$ docker logs docker-issuerservice-1 --since 5m 2>&1 | grep -c "resource_id does not exist"
0
$ curl -s http://localhost:8182/api/check/health | jq .isSystemHealthy
true
```

**identityhub DB — after fix:** schema unchanged; V0_0_3 applied as no-op (`success=t`).

---

### Changed files

| File | Change |
|---|---|
| V0_0_3__Ensure_Lease_Schema.sql | **New** — idempotent migration |

---

### Follow-up

Once this merges: the docker-compose PR will remove the "Known issues" section added to `deployment/docker/README.md` that documented this bug.