### PR TITLE
feat: add docker-compose for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ bin/
 out/
 .gradle/
 **.tgz
+
+# Docker Compose local secrets
+deployment/docker/.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For changes in other Tractus-X components, see the [Eclipse Tractus-X Changelog]
 
 ### Added
 
+- Add Docker Compose setup for local development under `deployment/docker/` ([BE-202](https://jira.example.org/browse/BE-202))
 - Add Flyway V0_0_2 migration scripts for EDC 0.15.1 DB schema changes ([#198](https://github.com/eclipse-tractusx/tractusx-identityhub/issues/198)):
   - `credential_resource`: new `usage` column
   - `keypair_resource`: new `usage` column

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -192,6 +192,12 @@ helm install issuerservice charts/tractusx-issuerservice/ \
 ```
 For helm chart options and configuration, see [Helm chart documentation](https://github.com/eclipse-tractusx/tractusx-identityhub/blob/main/charts/tractusx-issuerservice-memory/README.md)
 
+## Local development with Docker Compose
+
+As an alternative to Minikube and Helm, you can run all four runtimes locally using
+Docker Compose. See [deployment/docker/README.md](deployment/docker/README.md) for
+full usage instructions, including prerequisites and port reference.
+
 # Licenses
 
 - Apache-2.0 for code

--- a/deployment/docker/.env.example
+++ b/deployment/docker/.env.example
@@ -1,3 +1,23 @@
+#
+#  Copyright (c) 2026 Technovative Solutions
+#  Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 # PostgreSQL credentials (SQL profile only)
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres

--- a/deployment/docker/.env.example
+++ b/deployment/docker/.env.example
@@ -1,0 +1,8 @@
+# PostgreSQL credentials (SQL profile only)
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_PORT=5432
+
+# HashiCorp Vault root token (SQL profile, dev mode only – NOT for production)
+VAULT_TOKEN=token
+VAULT_PORT=8200

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -134,15 +134,17 @@ mounted read-only into the containers at `/app/configuration.properties`:
 
 ```
 config/
-  identityhub/configuration.properties        # SQL variant – vault + datasource URLs
-  identityhub-memory/configuration.properties # memory variant – no overrides needed
-  issuerservice/configuration.properties      # SQL variant – vault + datasource URLs
-  issuerservice-memory/configuration.properties # memory variant – no overrides needed
+  identityhub/configuration.properties        # SQL variant – full config with vault + datasource URLs
+  identityhub-memory/configuration.properties # memory variant – full config, no vault/DB settings
+  issuerservice/configuration.properties      # SQL variant – full config with vault + datasource URLs
+  issuerservice-memory/configuration.properties # memory variant – full config, no vault/DB settings
 ```
 
-The SQL override files point all datasources at `postgres:5432` and the Vault client at
-`http://vault:8200` (the compose service names), overriding the `localhost` defaults in
-the bundled `application.properties`.
+> **Important:** EDC's `-Dedc.fs.config` mechanism loads **only** the external file; it does
+> not merge with the `application.properties` bundled in the JAR. Each `configuration.properties`
+> here is therefore self-contained and mirrors the corresponding
+> `runtimes/*/src/main/resources/application.properties`, with the SQL variants also having
+> all datasource URLs and the Vault URL set to the compose service hostnames.
 
 ### Customising credentials
 
@@ -159,8 +161,9 @@ variables are documented in `.env.example`.
   schema initialisation is required beyond the database creation performed by
   `postgres/init/01-create-databases.sh`.
 - The `OTEL_JAR` build argument required by the existing Dockerfiles is satisfied by
-  passing the main runtime JAR as a placeholder. The OpenTelemetry javaagent line in the
-  `ENTRYPOINT` is commented out by default, so the placeholder is never loaded at runtime.
+  the OpenTelemetry agent downloaded to `build/resources/otel/opentelemetry-javaagent.jar`
+  during the Gradle build. The javaagent line in the `ENTRYPOINT` is commented out by
+  default, so it is copied into the image but not activated at runtime.
 
 ---
 

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -10,6 +10,10 @@ Two **profiles** are available:
 | `memory` | `identityhub-memory`, `issuerservice-memory` | Fastest dev loop; no external dependencies |
 | `sql` | `identityhub`, `issuerservice`, `postgres`, `vault` | Full stack with PostgreSQL + HashiCorp Vault |
 
+> **Note:** The `memory` and `sql` profiles share the same host ports (e.g. `8181`, `8182`,
+> `7171`, `7172`) and therefore **cannot be run simultaneously**. Stop one profile
+> (`docker compose --profile <name> down`) before starting the other.
+
 ---
 
 ## Prerequisites
@@ -50,17 +54,20 @@ The defaults (`postgres`/`postgres` credentials, Vault token `token`) work out o
 
 ```shell
 # Run from this directory (deployment/docker/)
-docker compose --profile memory up --build
+docker compose --profile memory up -d --build
 ```
 
 ### SQL profile (PostgreSQL + HashiCorp Vault)
 
 ```shell
-docker compose --profile sql up --build
+docker compose --profile sql up -d --build
 ```
 
-> **Note:** The `--build` flag is only needed on the first run or after rebuilding the JARs.
-> Subsequent starts can omit it: `docker compose --profile memory up`.
+> **Notes:**
+> - The `--build` flag is only needed on the first run or after rebuilding the JARs.
+>   Subsequent starts can omit it: `docker compose --profile memory up -d`.
+> - The `-d` flag runs containers in detached mode. Omit it to see logs streamed in the
+>   foreground; use `docker compose --profile <name> logs -f` to follow logs when detached.
 
 ---
 
@@ -79,7 +86,9 @@ docker compose --profile sql up --build
 
 ### issuerservice / issuerservice-memory
 
-Host ports that would conflict with identityhub are offset to avoid collisions when both services run simultaneously within the same profile.
+Within a single profile both runtimes start side-by-side, so the issuerservice host ports
+that would otherwise conflict with identityhub are offset by one (e.g. `8182` instead of `8181`).
+Container-internal ports remain identical for both runtimes.
 
 | Endpoint | Host port | Container port | Path |
 |----------|-----------|----------------|------|
@@ -103,12 +112,22 @@ Host ports that would conflict with identityhub are offset to avoid collisions w
 
 ## Quick health check
 
-```shell
-# Version endpoint – identityhub
-curl http://localhost:7171/.well-known/api
+The runtimes expose a JSON health endpoint on the default API port. A healthy response
+returns `"isSystemHealthy":true`; the `sql` profile additionally reports the `Hashicorp
+Vault Health` component.
 
-# Version endpoint – issuerservice
-curl http://localhost:7172/.well-known/api
+```shell
+# identityhub  (both profiles)
+curl http://localhost:8181/api/check/health
+
+# issuerservice  (both profiles)
+curl http://localhost:8182/api/check/health
+```
+
+Example output (SQL profile):
+
+```json
+{"componentResults":[{"failure":null,"component":"Hashicorp Vault Health","isHealthy":true},{"failure":null,"component":"BaseRuntime","isHealthy":true}],"isSystemHealthy":true}
 ```
 
 ---
@@ -157,9 +176,10 @@ variables are documented in `.env.example`.
 
 - **HashiCorp Vault runs in dev mode** — data is stored in memory and lost on container
   restart. This is intentional for local development. Never use dev mode in production.
-- **Liquibase migrations run automatically** at startup for the SQL variants; no manual
+- **Flyway migrations run automatically** at startup for the SQL variants; no manual
   schema initialisation is required beyond the database creation performed by
-  `postgres/init/01-create-databases.sh`.
+  `postgres/init/01-create-databases.sh`. Each store maintains its own
+  `flyway_schema_history_<store>` table in the target database.
 - The `OTEL_JAR` build argument required by the existing Dockerfiles is satisfied by
   the OpenTelemetry agent downloaded to `build/resources/otel/opentelemetry-javaagent.jar`
   during the Gradle build. The javaagent line in the `ENTRYPOINT` is commented out by

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -1,0 +1,170 @@
+# Local Development with Docker Compose
+
+This directory provides a Docker Compose setup for running all four runtime variants
+of tractusx-identityhub locally without requiring Minikube or Helm.
+
+Two **profiles** are available:
+
+| Profile | Services started | Use when |
+|---------|-----------------|----------|
+| `memory` | `identityhub-memory`, `issuerservice-memory` | Fastest dev loop; no external dependencies |
+| `sql` | `identityhub`, `issuerservice`, `postgres`, `vault` | Full stack with PostgreSQL + HashiCorp Vault |
+
+---
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) with Compose v2 (`docker compose version` ≥ 2.14)
+- JDK 21+ and [Gradle](https://gradle.org/) (or use the wrapper `./gradlew`)
+
+---
+
+## Step 1 — Build the runtime JARs
+
+Run from the **repository root**:
+
+```shell
+./gradlew shadowJar
+```
+
+This produces all four JARs under their respective `runtimes/*/build/libs/` directories and
+also processes resources (including `logging.properties`) required by the Docker build.
+
+---
+
+## Step 2 — Configure environment variables (optional)
+
+Copy `.env.example` to `.env` inside this directory and adjust values if needed:
+
+```shell
+cp .env.example .env
+```
+
+The defaults (`postgres`/`postgres` credentials, Vault token `token`) work out of the box.
+
+---
+
+## Step 3 — Start the services
+
+### Memory profile (no database, no Vault)
+
+```shell
+# Run from this directory (deployment/docker/)
+docker compose --profile memory up --build
+```
+
+### SQL profile (PostgreSQL + HashiCorp Vault)
+
+```shell
+docker compose --profile sql up --build
+```
+
+> **Note:** The `--build` flag is only needed on the first run or after rebuilding the JARs.
+> Subsequent starts can omit it: `docker compose --profile memory up`.
+
+---
+
+## Port reference
+
+### identityhub / identityhub-memory
+
+| Endpoint | Host port | Container port | Path |
+|----------|-----------|----------------|------|
+| Default API | 8181 | 8181 | `/api` |
+| Version | 7171 | 7171 | `/.well-known/api` |
+| Credentials API | 13131 | 13131 | `/api/credentials` |
+| DID | 10100 | 10100 | `/` |
+| Identity API | 15151 | 15151 | `/api/identity` |
+| STS | 9292 | 9292 | `/api/sts` |
+
+### issuerservice / issuerservice-memory
+
+Host ports that would conflict with identityhub are offset to avoid collisions when both services run simultaneously within the same profile.
+
+| Endpoint | Host port | Container port | Path |
+|----------|-----------|----------------|------|
+| Default API | 8182 | 8181 | `/api` |
+| Version | 7172 | 7171 | `/.well-known/api` |
+| Issuance API | 13132 | 13132 | `/api/issuance` |
+| DID | 10101 | 10100 | `/` |
+| Identity API | 15251 | 15151 | `/api/identity` |
+| Issuer Admin API | 15152 | 15152 | `/api/issuer` |
+| STS | 9392 | 9292 | `/api/sts` |
+| Status List | 9999 | 9999 | `/statuslist` |
+
+### SQL profile – infrastructure
+
+| Service | Host port | Notes |
+|---------|-----------|-------|
+| PostgreSQL | 5432 | Configurable via `POSTGRES_PORT` in `.env` |
+| HashiCorp Vault | 8200 | Configurable via `VAULT_PORT` in `.env` |
+
+---
+
+## Quick health check
+
+```shell
+# Version endpoint – identityhub
+curl http://localhost:7171/.well-known/api
+
+# Version endpoint – issuerservice
+curl http://localhost:7172/.well-known/api
+```
+
+---
+
+## Stopping and cleaning up
+
+```shell
+# Stop and remove containers (keep volumes)
+docker compose --profile memory down
+# or
+docker compose --profile sql down
+
+# Remove containers AND the postgres volume (full reset)
+docker compose --profile sql down -v
+```
+
+---
+
+## Configuration
+
+The `config/` subdirectory contains per-runtime `configuration.properties` files that are
+mounted read-only into the containers at `/app/configuration.properties`:
+
+```
+config/
+  identityhub/configuration.properties        # SQL variant – vault + datasource URLs
+  identityhub-memory/configuration.properties # memory variant – no overrides needed
+  issuerservice/configuration.properties      # SQL variant – vault + datasource URLs
+  issuerservice-memory/configuration.properties # memory variant – no overrides needed
+```
+
+The SQL override files point all datasources at `postgres:5432` and the Vault client at
+`http://vault:8200` (the compose service names), overriding the `localhost` defaults in
+the bundled `application.properties`.
+
+### Customising credentials
+
+Edit `.env` or set environment variables before running `docker compose`. The available
+variables are documented in `.env.example`.
+
+---
+
+## Notes
+
+- **HashiCorp Vault runs in dev mode** — data is stored in memory and lost on container
+  restart. This is intentional for local development. Never use dev mode in production.
+- **Liquibase migrations run automatically** at startup for the SQL variants; no manual
+  schema initialisation is required beyond the database creation performed by
+  `postgres/init/01-create-databases.sh`.
+- The `OTEL_JAR` build argument required by the existing Dockerfiles is satisfied by
+  passing the main runtime JAR as a placeholder. The OpenTelemetry javaagent line in the
+  `ENTRYPOINT` is commented out by default, so the placeholder is never loaded at runtime.
+
+---
+
+## Licenses
+
+- Apache-2.0 for code
+- CC-BY-4.0 for non-code

--- a/deployment/docker/config/identityhub-memory/configuration.properties
+++ b/deployment/docker/config/identityhub-memory/configuration.properties
@@ -1,4 +1,5 @@
 #
+#  Copyright (c) 2026 Technovative Solutions
 #  Copyright (c) 2026 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional

--- a/deployment/docker/config/identityhub-memory/configuration.properties
+++ b/deployment/docker/config/identityhub-memory/configuration.properties
@@ -1,0 +1,24 @@
+#
+#  Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Docker Compose override configuration for identityhub-memory (in-memory variant).
+#  Mounted as /app/configuration.properties inside the container.
+#
+#  No datasource or vault configuration is required; all ports, paths, and
+#  runtime settings are inherited from application.properties bundled inside the JAR.
+#

--- a/deployment/docker/config/identityhub-memory/configuration.properties
+++ b/deployment/docker/config/identityhub-memory/configuration.properties
@@ -16,9 +16,93 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-#  Docker Compose override configuration for identityhub-memory (in-memory variant).
+#  Docker Compose configuration for identityhub-memory (in-memory variant).
 #  Mounted as /app/configuration.properties inside the container.
 #
-#  No datasource or vault configuration is required; all ports, paths, and
-#  runtime settings are inherited from application.properties bundled inside the JAR.
+#  This file is self-contained: EDC loads only this external file and does NOT
+#  merge it with the classpath application.properties bundled in the JAR.
+#  Content mirrors runtimes/identityhub-memory/src/main/resources/application.properties.
 #
+
+# DEFAULT CONFIGURATION
+web.http.port=8181
+web.http.path=/api
+web.http.default.port=8181
+web.http.default.path=/api
+
+# VERSION CONFIGURATION
+web.http.version.port=7171
+web.http.version.path=/.well-known/api
+
+# CREDENTIALS CONFIGURATION
+web.http.credentials.port=13131
+web.http.credentials.path=/api/credentials
+
+# DID CONFIGURATION
+web.http.did.port=10100
+web.http.did.path=/
+
+# IDENTITY CONFIGURATION
+web.http.identity.port=15151
+web.http.identity.path=/api/identity
+
+# STS CONFIGURATION
+web.http.sts.port=9292
+web.http.sts.path=/api/sts
+edc.iam.sts.token.expiration=5
+
+edc.iam.accesstoken.jti.validation=false
+edc.iam.credential.revocation.cache.validity=900000
+edc.iam.credential.revocation.mimetype=*
+
+edc.sql.store.stsclient.datasource=default
+edc.sql.store.didresource.datasource=default
+edc.sql.store.credentials.datasource=default
+edc.sql.store.participantcontext.datasource=default
+edc.sql.store.holder.datasource=default
+edc.sql.store.issuanceprocess.datasource=default
+edc.sql.store.credentialdefinitions.datasource=default
+edc.sql.store.credentialrequest.datasource=default
+edc.sql.store.keypair.datasource=default
+edc.sql.store.attestationdefinitions.datasource=default
+edc.sql.store.participantcontextconfig.datasource=default
+
+# CREDENTIAL WATCHDOG CONFIGURATION
+edc.iam.credential.status.check.period=60
+edc.iam.credential.status.check.delay=5
+edc.iam.credential.renewal.graceperiod=604800
+
+#edc.ih.api.superuser.key
+edc.ih.api.superuser.id=super-user
+
+###############################
+# EDC CONNECTOR CONFIGURATION #
+###############################
+edc.jsonld.vocab.disable=false
+edc.jsonld.prefixes.check=true
+edc.jsonld.http.enabled=false
+edc.jsonld.https.enabled=false
+
+edc.did.resolver.cache.expiry=300000
+
+edc.web.https.keystore.type=PKCS12
+edc.web.https.keystore.password=password
+edc.web.https.keymanager.password=password
+
+edc.http.client.https.enforce=false
+edc.http.client.timeout.connect=30
+edc.http.client.timeout.read=30
+edc.http.client.send.buffer.size=1
+edc.http.client.receive.buffer.size=1
+
+edc.core.retry.retries.max=5
+edc.core.retry.backoff.min=500
+edc.core.retry.backoff.max=10000
+edc.core.retry.log.on.retry=false
+edc.core.retry.log.on.retry.scheduled=false
+edc.core.retry.log.on.retries.exceeded=false
+edc.core.retry.log.on.failed.attempt=false
+edc.core.retry.log.on.abort=false
+
+edc.agent.identity.key=client_id
+edc.hostname=localhost

--- a/deployment/docker/config/identityhub/configuration.properties
+++ b/deployment/docker/config/identityhub/configuration.properties
@@ -1,4 +1,5 @@
 #
+#  Copyright (c) 2026 Technovative Solutions
 #  Copyright (c) 2026 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional

--- a/deployment/docker/config/identityhub/configuration.properties
+++ b/deployment/docker/config/identityhub/configuration.properties
@@ -16,27 +16,146 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-#  Docker Compose override configuration for identityhub (SQL variant).
+#  Docker Compose configuration for identityhub (SQL + HashiCorp Vault variant).
 #  Mounted as /app/configuration.properties inside the container.
-#  Overrides entries that must reference compose service hostnames instead of localhost.
+#
+#  This file is self-contained: EDC loads only this external file and does NOT
+#  merge it with the classpath application.properties bundled in the JAR.
+#  Based on runtimes/identityhub/src/main/resources/application.properties with
+#  datasource URLs and Vault URL overridden to use compose service hostnames.
 #
 
-# HashiCorp Vault – points at the "vault" compose service
+# DEFAULT CONFIGURATION
+web.http.port=8181
+web.http.path=/api
+web.http.default.port=8181
+web.http.default.path=/api
+
+# VERSION CONFIGURATION
+web.http.version.port=7171
+web.http.version.path=/.well-known/api
+
+# CREDENTIALS CONFIGURATION
+web.http.credentials.port=13131
+web.http.credentials.path=/api/credentials
+
+# DID CONFIGURATION
+web.http.did.port=10100
+web.http.did.path=/
+
+# IDENTITY CONFIGURATION
+web.http.identity.port=15151
+web.http.identity.path=/api/identity
+
+# STS CONFIGURATION
+web.http.sts.port=9292
+web.http.sts.path=/api/sts
+edc.iam.sts.token.expiration=5
+
+edc.iam.accesstoken.jti.validation=false
+edc.iam.credential.revocation.cache.validity=900000
+edc.iam.credential.revocation.mimetype=*
+
+# CREDENTIAL WATCHDOG CONFIGURATION
+edc.iam.credential.status.check.period=60
+edc.iam.credential.status.check.delay=5
+edc.iam.credential.renewal.graceperiod=604800
+
+#edc.ih.api.superuser.key
+edc.ih.api.superuser.id=super-user
+
+# HASHICORP VAULT CONFIGURATION – points at the "vault" compose service
 edc.vault.hashicorp.url=http://vault:8200
 edc.vault.hashicorp.token=token
 edc.vault.hashicorp.token.scheduled-renew-enabled=false
+edc.vault.hashicorp.token.ttl=300
+edc.vault.hashicorp.token.renew-buffer=30
 
-# Default datasource – used by all SQL stores routed via edc.sql.store.*.datasource=default
-edc.datasource.default.url=jdbc:postgresql://postgres:5432/identityhub
-edc.datasource.default.user=postgres
-edc.datasource.default.password=postgres
+############################
+# DATASOURCE CONFIGURATION #
+# Mirrors the tractusx-identityhub Helm chart datasource config exactly.
+# Each store uses its own named datasource pointing to the identityhub DB.
+# Stores NOT listed here (holder, issuanceprocess, credentialdefinitions,
+# attestationdefinitions) belong to issuerservice and are intentionally omitted:
+# running their migrations here would cause edc_lease schema conflicts.
+############################
 
-# participantcontextconfig uses a dedicated named datasource (see base application.properties)
+# participant context
+edc.sql.store.participantcontext.datasource=participantcontext
+edc.datasource.participantcontext.url=jdbc:postgresql://postgres:5432/identityhub
+edc.datasource.participantcontext.user=postgres
+edc.datasource.participantcontext.password=postgres
+
+# keypair
+edc.sql.store.keypair.datasource=keypair
+edc.datasource.keypair.url=jdbc:postgresql://postgres:5432/identityhub
+edc.datasource.keypair.user=postgres
+edc.datasource.keypair.password=postgres
+
+# did documents
+edc.sql.store.didresource.datasource=didresource
+edc.datasource.didresource.url=jdbc:postgresql://postgres:5432/identityhub
+edc.datasource.didresource.user=postgres
+edc.datasource.didresource.password=postgres
+
+# STS Client
+edc.sql.store.stsclient.datasource=stsclient
+edc.datasource.stsclient.url=jdbc:postgresql://postgres:5432/identityhub
+edc.datasource.stsclient.user=postgres
+edc.datasource.stsclient.password=postgres
+
+# HolderCredentialRequests
+edc.sql.store.credentialrequest.datasource=credentialrequest
+edc.datasource.credentialrequest.url=jdbc:postgresql://postgres:5432/identityhub
+edc.datasource.credentialrequest.user=postgres
+edc.datasource.credentialrequest.password=postgres
+
+# VerifiableCredentialResources
+edc.sql.store.credentials.datasource=credentials
+edc.datasource.credentials.url=jdbc:postgresql://postgres:5432/identityhub
+edc.datasource.credentials.user=postgres
+edc.datasource.credentials.password=postgres
+
+# JTI validation
+edc.sql.store.jti.datasource=jti
+edc.datasource.jti.url=jdbc:postgresql://postgres:5432/identityhub
+edc.datasource.jti.user=postgres
+edc.datasource.jti.password=postgres
+
+# Participant Context Config
+edc.sql.store.participantcontextconfig.datasource=participantcontextconfig
 edc.datasource.participantcontextconfig.url=jdbc:postgresql://postgres:5432/identityhub
 edc.datasource.participantcontextconfig.user=postgres
 edc.datasource.participantcontextconfig.password=postgres
 
-# jti store uses its own named datasource (no default routing in base config)
-edc.datasource.jti.url=jdbc:postgresql://postgres:5432/identityhub
-edc.datasource.jti.user=postgres
-edc.datasource.jti.password=postgres
+###############################
+# EDC CONNECTOR CONFIGURATION #
+###############################
+edc.jsonld.vocab.disable=false
+edc.jsonld.prefixes.check=true
+edc.jsonld.http.enabled=false
+edc.jsonld.https.enabled=false
+
+edc.did.resolver.cache.expiry=300000
+
+edc.web.https.keystore.type=PKCS12
+edc.web.https.keystore.password=password
+edc.web.https.keymanager.password=password
+
+edc.http.client.https.enforce=false
+edc.http.client.timeout.connect=30
+edc.http.client.timeout.read=30
+edc.http.client.send.buffer.size=1
+edc.http.client.receive.buffer.size=1
+
+edc.core.retry.retries.max=5
+edc.core.retry.backoff.min=500
+edc.core.retry.backoff.max=10000
+edc.core.retry.log.on.retry=false
+edc.core.retry.log.on.retry.scheduled=false
+edc.core.retry.log.on.retries.exceeded=false
+edc.core.retry.log.on.failed.attempt=false
+edc.core.retry.log.on.abort=false
+
+edc.agent.identity.key=client_id
+edc.hostname=localhost

--- a/deployment/docker/config/identityhub/configuration.properties
+++ b/deployment/docker/config/identityhub/configuration.properties
@@ -1,0 +1,42 @@
+#
+#  Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Docker Compose override configuration for identityhub (SQL variant).
+#  Mounted as /app/configuration.properties inside the container.
+#  Overrides entries that must reference compose service hostnames instead of localhost.
+#
+
+# HashiCorp Vault – points at the "vault" compose service
+edc.vault.hashicorp.url=http://vault:8200
+edc.vault.hashicorp.token=token
+edc.vault.hashicorp.token.scheduled-renew-enabled=false
+
+# Default datasource – used by all SQL stores routed via edc.sql.store.*.datasource=default
+edc.datasource.default.url=jdbc:postgresql://postgres:5432/identityhub
+edc.datasource.default.user=postgres
+edc.datasource.default.password=postgres
+
+# participantcontextconfig uses a dedicated named datasource (see base application.properties)
+edc.datasource.participantcontextconfig.url=jdbc:postgresql://postgres:5432/identityhub
+edc.datasource.participantcontextconfig.user=postgres
+edc.datasource.participantcontextconfig.password=postgres
+
+# jti store uses its own named datasource (no default routing in base config)
+edc.datasource.jti.url=jdbc:postgresql://postgres:5432/identityhub
+edc.datasource.jti.user=postgres
+edc.datasource.jti.password=postgres

--- a/deployment/docker/config/issuerservice-memory/configuration.properties
+++ b/deployment/docker/config/issuerservice-memory/configuration.properties
@@ -1,4 +1,5 @@
 #
+#  Copyright (c) 2026 Technovative Solutions
 #  Copyright (c) 2026 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional

--- a/deployment/docker/config/issuerservice-memory/configuration.properties
+++ b/deployment/docker/config/issuerservice-memory/configuration.properties
@@ -1,0 +1,24 @@
+#
+#  Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Docker Compose override configuration for issuerservice-memory (in-memory variant).
+#  Mounted as /app/configuration.properties inside the container.
+#
+#  No datasource or vault configuration is required; all ports, paths, and
+#  runtime settings are inherited from application.properties bundled inside the JAR.
+#

--- a/deployment/docker/config/issuerservice-memory/configuration.properties
+++ b/deployment/docker/config/issuerservice-memory/configuration.properties
@@ -16,9 +16,77 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-#  Docker Compose override configuration for issuerservice-memory (in-memory variant).
+#  Docker Compose configuration for issuerservice-memory (in-memory variant).
 #  Mounted as /app/configuration.properties inside the container.
 #
-#  No datasource or vault configuration is required; all ports, paths, and
-#  runtime settings are inherited from application.properties bundled inside the JAR.
+#  This file is self-contained: EDC loads only this external file and does NOT
+#  merge it with the classpath application.properties bundled in the JAR.
+#  Content mirrors runtimes/issuerservice-memory/src/main/resources/application.properties.
 #
+
+edc.hostname=localhost
+edc.issuer.statuslist.signing.key.alias=test
+
+edc.core.retry.retries.max=5
+edc.core.retry.backoff.min=500
+edc.core.retry.backoff.max=10000
+edc.core.retry.log.on.retry=false
+edc.core.retry.log.on.retry.scheduled=false
+edc.core.retry.log.on.retries.exceeded=false
+edc.core.retry.log.on.failed.attempt=false
+edc.core.retry.log.on.abort=false
+
+edc.http.client.https.enforce=false
+edc.http.client.timeout.connect=30
+edc.http.client.timeout.read=30
+edc.http.client.send.buffer.size=0
+edc.http.client.receive.buffer.size=0
+
+edc.jsonld.http.enabled=false
+edc.jsonld.prefixes.check=true
+edc.jsonld.https.enabled=false
+edc.jsonld.vocab.disable=false
+
+edc.iam.accesstoken.jti.validation=false
+edc.iam.credential.revocation.cache.validity=900000
+edc.iam.sts.token.expiration=5
+
+edc.did.resolver.cache.expiry=300000
+
+edc.web.https.keystore.type=PKC512
+edc.web.https.keystore.password=password
+edc.web.https.keymanager.password=password
+
+edc.issuer.issuance.state-machine.batch-size=20
+edc.issuer.issuance.send.retry.limit=7
+edc.issuer.issuance.state-machine.iteration-wait-millis=1000
+edc.issuer.issuance.send.retry.base-delay.ms=1000
+
+###########################
+# ENDPOINTS CONFIGURATION #
+###########################
+web.http.default.port=8181
+web.http.default.path=/api
+web.http.port=8181
+web.http.path=/api
+
+web.http.statuslist.port=9999
+web.http.statuslist.path=/statuslist
+
+web.http.did.port=10100
+web.http.did.path=/
+
+web.http.issuance.port=13132
+web.http.issuance.path=/api/issuance
+
+web.http.identity.port=15151
+web.http.identity.path=/api/identity
+
+web.http.issueradmin.port=15152
+web.http.issueradmin.path=/api/issuer
+
+web.http.sts.port=9292
+web.http.sts.path=/api/sts
+
+web.http.version.port=7171
+web.http.version.path=/.well-known/api

--- a/deployment/docker/config/issuerservice/configuration.properties
+++ b/deployment/docker/config/issuerservice/configuration.properties
@@ -1,4 +1,5 @@
 #
+#  Copyright (c) 2026 Technovative Solutions
 #  Copyright (c) 2026 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional

--- a/deployment/docker/config/issuerservice/configuration.properties
+++ b/deployment/docker/config/issuerservice/configuration.properties
@@ -16,58 +16,180 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 #
-#  Docker Compose override configuration for issuerservice (SQL variant).
+#  Docker Compose configuration for issuerservice (SQL + HashiCorp Vault variant).
 #  Mounted as /app/configuration.properties inside the container.
-#  Overrides entries that must reference compose service hostnames instead of localhost.
+#
+#  This file is self-contained: EDC loads only this external file and does NOT
+#  merge it with the classpath application.properties bundled in the JAR.
+#  Based on runtimes/issuerservice/src/main/resources/application.properties with
+#  datasource URLs and Vault URL overridden to use compose service hostnames.
 #
 
-# HashiCorp Vault – points at the "vault" compose service
+edc.hostname=localhost
+edc.issuer.statuslist.signing.key.alias=test
+
+edc.core.retry.retries.max=5
+edc.core.retry.backoff.min=500
+edc.core.retry.backoff.max=10000
+edc.core.retry.log.on.retry=false
+edc.core.retry.log.on.retry.scheduled=false
+edc.core.retry.log.on.retries.exceeded=false
+edc.core.retry.log.on.failed.attempt=false
+edc.core.retry.log.on.abort=false
+
+edc.http.client.https.enforce=false
+edc.http.client.timeout.connect=30
+edc.http.client.timeout.read=30
+edc.http.client.send.buffer.size=0
+edc.http.client.receive.buffer.size=0
+
+edc.jsonld.http.enabled=false
+edc.jsonld.prefixes.check=true
+edc.jsonld.https.enabled=false
+edc.jsonld.vocab.disable=false
+
+edc.iam.accesstoken.jti.validation=false
+edc.iam.credential.revocation.cache.validity=900000
+edc.iam.sts.token.expiration=5
+
+edc.did.resolver.cache.expiry=300000
+
+edc.web.https.keystore.type=PKC512
+edc.web.https.keystore.password=password
+edc.web.https.keymanager.password=password
+
+edc.issuer.issuance.state-machine.batch-size=20
+edc.issuer.issuance.send.retry.limit=7
+edc.issuer.issuance.state-machine.iteration-wait-millis=1000
+edc.issuer.issuance.send.retry.base-delay.ms=1000
+
+edc.sql.fetch.size=5000
+edc.sql.schema.autocreate=false
+
+#################################
+# VAULT HASHICORP CONFIGURATION #
+# Points at the "vault" compose service
+#################################
 edc.vault.hashicorp.url=http://vault:8200
 edc.vault.hashicorp.token=token
 edc.vault.hashicorp.token.scheduled-renew-enabled=false
+edc.vault.hashicorp.token.ttl=300
+edc.vault.hashicorp.token.renew-buffer=30
 
-# Default datasource – used by stores routed via edc.sql.store.*.datasource=default
-edc.datasource.default.url=jdbc:postgresql://postgres:5432/issuerservice
-edc.datasource.default.user=postgres
-edc.datasource.default.password=postgres
+############################
+# DATASOURCE CONFIGURATION #
+# All datasources point at the "postgres" compose service
+#
+# NOTE: AbstractPostgresqlMigrationExtension reads edc.datasource.<subsystem>.url
+# directly. It uses edc.sql.store.<name>.datasource only as a nil-check guard:
+# if that key is absent (null), migration is skipped entirely. Both the routing
+# key AND the named datasource URL are therefore required for each store.
+############################
 
-# Per-store named datasources – all share the same issuerservice database
+############################
+# DATASOURCE CONFIGURATION #
+# Mirrors the tractusx-issuerservice Helm chart datasource config exactly.
+# Each store uses its own named datasource pointing to the issuerservice DB.
+# credentialrequest is intentionally omitted (identityhub domain only).
+############################
+
+# issuance process
+edc.sql.store.issuanceprocess.datasource=issuanceprocess
 edc.datasource.issuanceprocess.url=jdbc:postgresql://postgres:5432/issuerservice
 edc.datasource.issuanceprocess.user=postgres
 edc.datasource.issuanceprocess.password=postgres
 
+# attestation definitions
+edc.sql.store.attestationdefinitions.datasource=attestationdefinitions
 edc.datasource.attestationdefinitions.url=jdbc:postgresql://postgres:5432/issuerservice
 edc.datasource.attestationdefinitions.user=postgres
 edc.datasource.attestationdefinitions.password=postgres
 
+# credential definitions
+edc.sql.store.credentialdefinitions.datasource=credentialdefinitions
+edc.datasource.credentialdefinitions.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.credentialdefinitions.user=postgres
+edc.datasource.credentialdefinitions.password=postgres
+
+# did documents
+edc.sql.store.didresource.datasource=didresource
 edc.datasource.didresource.url=jdbc:postgresql://postgres:5432/issuerservice
 edc.datasource.didresource.user=postgres
 edc.datasource.didresource.password=postgres
 
-edc.datasource.participant.url=jdbc:postgresql://postgres:5432/issuerservice
-edc.datasource.participant.user=postgres
-edc.datasource.participant.password=postgres
-
-edc.datasource.participantcontext.url=jdbc:postgresql://postgres:5432/issuerservice
-edc.datasource.participantcontext.user=postgres
-edc.datasource.participantcontext.password=postgres
-
-edc.datasource.keypair.url=jdbc:postgresql://postgres:5432/issuerservice
-edc.datasource.keypair.user=postgres
-edc.datasource.keypair.password=postgres
-
+# STS Client
+edc.sql.store.stsclient.datasource=stsclient
 edc.datasource.stsclient.url=jdbc:postgresql://postgres:5432/issuerservice
 edc.datasource.stsclient.user=postgres
 edc.datasource.stsclient.password=postgres
 
+# Participants
+edc.sql.store.participant.datasource=participant
+edc.datasource.participant.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.participant.user=postgres
+edc.datasource.participant.password=postgres
+
+# Participant Contexts
+edc.sql.store.participantcontext.datasource=participantcontext
+edc.datasource.participantcontext.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.participantcontext.user=postgres
+edc.datasource.participantcontext.password=postgres
+
+# KeyPairs
+edc.sql.store.keypair.datasource=keypair
+edc.datasource.keypair.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.keypair.user=postgres
+edc.datasource.keypair.password=postgres
+
+# JTI validation
+edc.sql.store.jti.datasource=jti
 edc.datasource.jti.url=jdbc:postgresql://postgres:5432/issuerservice
 edc.datasource.jti.user=postgres
 edc.datasource.jti.password=postgres
 
+# VerifiableCredentialResources
+edc.sql.store.credentials.datasource=credentials
+edc.datasource.credentials.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.credentials.user=postgres
+edc.datasource.credentials.password=postgres
+
+# Holders
+edc.sql.store.holder.datasource=holder
+edc.datasource.holder.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.holder.user=postgres
+edc.datasource.holder.password=postgres
+
+# Participant Context Config
+edc.sql.store.participantcontextconfig.datasource=participantcontextconfig
 edc.datasource.participantcontextconfig.url=jdbc:postgresql://postgres:5432/issuerservice
 edc.datasource.participantcontextconfig.user=postgres
 edc.datasource.participantcontextconfig.password=postgres
 
-edc.datasource.credentialdefinition.url=jdbc:postgresql://postgres:5432/issuerservice
-edc.datasource.credentialdefinition.user=postgres
-edc.datasource.credentialdefinition.password=postgres
+###########################
+# ENDPOINTS CONFIGURATION #
+###########################
+web.http.default.port=8181
+web.http.default.path=/api
+web.http.port=8181
+web.http.path=/api
+
+web.http.statuslist.port=9999
+web.http.statuslist.path=/statuslist
+
+web.http.did.port=10100
+web.http.did.path=/
+
+web.http.issuance.port=13132
+web.http.issuance.path=/api/issuance
+
+web.http.identity.port=15151
+web.http.identity.path=/api/identity
+
+web.http.issueradmin.port=15152
+web.http.issueradmin.path=/api/issuer
+
+web.http.sts.port=9292
+web.http.sts.path=/api/sts
+
+web.http.version.port=7171
+web.http.version.path=/.well-known/api

--- a/deployment/docker/config/issuerservice/configuration.properties
+++ b/deployment/docker/config/issuerservice/configuration.properties
@@ -1,0 +1,73 @@
+#
+#  Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Docker Compose override configuration for issuerservice (SQL variant).
+#  Mounted as /app/configuration.properties inside the container.
+#  Overrides entries that must reference compose service hostnames instead of localhost.
+#
+
+# HashiCorp Vault – points at the "vault" compose service
+edc.vault.hashicorp.url=http://vault:8200
+edc.vault.hashicorp.token=token
+edc.vault.hashicorp.token.scheduled-renew-enabled=false
+
+# Default datasource – used by stores routed via edc.sql.store.*.datasource=default
+edc.datasource.default.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.default.user=postgres
+edc.datasource.default.password=postgres
+
+# Per-store named datasources – all share the same issuerservice database
+edc.datasource.issuanceprocess.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.issuanceprocess.user=postgres
+edc.datasource.issuanceprocess.password=postgres
+
+edc.datasource.attestationdefinitions.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.attestationdefinitions.user=postgres
+edc.datasource.attestationdefinitions.password=postgres
+
+edc.datasource.didresource.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.didresource.user=postgres
+edc.datasource.didresource.password=postgres
+
+edc.datasource.participant.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.participant.user=postgres
+edc.datasource.participant.password=postgres
+
+edc.datasource.participantcontext.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.participantcontext.user=postgres
+edc.datasource.participantcontext.password=postgres
+
+edc.datasource.keypair.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.keypair.user=postgres
+edc.datasource.keypair.password=postgres
+
+edc.datasource.stsclient.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.stsclient.user=postgres
+edc.datasource.stsclient.password=postgres
+
+edc.datasource.jti.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.jti.user=postgres
+edc.datasource.jti.password=postgres
+
+edc.datasource.participantcontextconfig.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.participantcontextconfig.user=postgres
+edc.datasource.participantcontextconfig.password=postgres
+
+edc.datasource.credentialdefinition.url=jdbc:postgresql://postgres:5432/issuerservice
+edc.datasource.credentialdefinition.user=postgres
+edc.datasource.credentialdefinition.password=postgres

--- a/deployment/docker/docker-compose.yaml
+++ b/deployment/docker/docker-compose.yaml
@@ -1,4 +1,5 @@
 #################################################################################
+#  Copyright (c) 2026 Technovative Solutions
 #  Copyright (c) 2026 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional

--- a/deployment/docker/docker-compose.yaml
+++ b/deployment/docker/docker-compose.yaml
@@ -1,0 +1,197 @@
+#################################################################################
+#  Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+#
+# Run in-memory profile (no Postgres, no Vault):
+#   docker compose --profile memory up
+#
+# Run SQL profile (Postgres + HashiCorp Vault):
+#   docker compose --profile sql up
+#
+# Prerequisites: run ./gradlew shadowJar from the repository root first.
+# See deployment/docker/README.md for full usage instructions.
+
+services:
+
+  # ---------------------------------------------------------------------------
+  # PostgreSQL – SQL profile only
+  # ---------------------------------------------------------------------------
+  postgres:
+    image: postgres:16-alpine
+    profiles: [sql]
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: postgres
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+      - ./postgres/init:/docker-entrypoint-initdb.d:ro
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    networks:
+      - tractusx-identityhub
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # ---------------------------------------------------------------------------
+  # HashiCorp Vault (dev mode) – SQL profile only
+  # WARNING: dev mode is for local development only; never use in production.
+  # ---------------------------------------------------------------------------
+  vault:
+    image: hashicorp/vault:1.17
+    profiles: [sql]
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: ${VAULT_TOKEN:-token}
+      VAULT_DEV_LISTEN_ADDRESS: "0.0.0.0:8200"
+    cap_add:
+      - IPC_LOCK
+    ports:
+      - "${VAULT_PORT:-8200}:8200"
+    networks:
+      - tractusx-identityhub
+    healthcheck:
+      test: ["CMD", "vault", "status", "-address=http://127.0.0.1:8200"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # ---------------------------------------------------------------------------
+  # IdentityHub (SQL + HashiCorp Vault) – SQL profile
+  # ---------------------------------------------------------------------------
+  identityhub:
+    build:
+      context: ../../runtimes/identityhub
+      dockerfile: Dockerfile
+      args:
+        JAR: build/libs/identityhub.jar
+        # OTEL_JAR is required by the Dockerfile; the main JAR is used as a
+        # placeholder because the javaagent is disabled in the ENTRYPOINT by default.
+        OTEL_JAR: build/libs/identityhub.jar
+        ADDITIONAL_FILES: build/resources/main/logging.properties
+    profiles: [sql]
+    depends_on:
+      postgres:
+        condition: service_healthy
+      vault:
+        condition: service_healthy
+    volumes:
+      - ./config/identityhub/configuration.properties:/app/configuration.properties:ro
+    ports:
+      - "8181:8181"   # default API      – /api
+      - "7171:7171"   # version          – /.well-known/api
+      - "13131:13131" # credentials API  – /api/credentials
+      - "10100:10100" # DID              – /
+      - "15151:15151" # identity API     – /api/identity
+      - "9292:9292"   # STS              – /api/sts
+    networks:
+      - tractusx-identityhub
+
+  # ---------------------------------------------------------------------------
+  # IssuerService (SQL + HashiCorp Vault) – SQL profile
+  # Host ports for endpoints shared with identityhub are offset to avoid conflicts.
+  # ---------------------------------------------------------------------------
+  issuerservice:
+    build:
+      context: ../../runtimes/issuerservice
+      dockerfile: Dockerfile
+      args:
+        JAR: build/libs/issuerservice.jar
+        OTEL_JAR: build/libs/issuerservice.jar
+        ADDITIONAL_FILES: build/resources/main/logging.properties
+    profiles: [sql]
+    depends_on:
+      postgres:
+        condition: service_healthy
+      vault:
+        condition: service_healthy
+    volumes:
+      - ./config/issuerservice/configuration.properties:/app/configuration.properties:ro
+    ports:
+      - "8182:8181"   # default API      – /api
+      - "7172:7171"   # version          – /.well-known/api
+      - "13132:13132" # issuance API     – /api/issuance
+      - "10101:10100" # DID              – /
+      - "15251:15151" # identity API     – /api/identity
+      - "15152:15152" # issuer admin API – /api/issuer
+      - "9392:9292"   # STS              – /api/sts
+      - "9999:9999"   # status list      – /statuslist
+    networks:
+      - tractusx-identityhub
+
+  # ---------------------------------------------------------------------------
+  # IdentityHub (in-memory) – memory profile
+  # ---------------------------------------------------------------------------
+  identityhub-memory:
+    build:
+      context: ../../runtimes/identityhub-memory
+      dockerfile: Dockerfile
+      args:
+        JAR: build/libs/identityhub-memory.jar
+        OTEL_JAR: build/libs/identityhub-memory.jar
+        ADDITIONAL_FILES: build/resources/main/logging.properties
+    profiles: [memory]
+    volumes:
+      - ./config/identityhub-memory/configuration.properties:/app/configuration.properties:ro
+    ports:
+      - "8181:8181"   # default API      – /api
+      - "7171:7171"   # version          – /.well-known/api
+      - "13131:13131" # credentials API  – /api/credentials
+      - "10100:10100" # DID              – /
+      - "15151:15151" # identity API     – /api/identity
+      - "9292:9292"   # STS              – /api/sts
+    networks:
+      - tractusx-identityhub
+
+  # ---------------------------------------------------------------------------
+  # IssuerService (in-memory) – memory profile
+  # Host ports for endpoints shared with identityhub-memory are offset to avoid conflicts.
+  # ---------------------------------------------------------------------------
+  issuerservice-memory:
+    build:
+      context: ../../runtimes/issuerservice-memory
+      dockerfile: Dockerfile
+      args:
+        JAR: build/libs/issuerservice-memory.jar
+        OTEL_JAR: build/libs/issuerservice-memory.jar
+        ADDITIONAL_FILES: build/resources/main/logging.properties
+    profiles: [memory]
+    volumes:
+      - ./config/issuerservice-memory/configuration.properties:/app/configuration.properties:ro
+    ports:
+      - "8182:8181"   # default API      – /api
+      - "7172:7171"   # version          – /.well-known/api
+      - "13132:13132" # issuance API     – /api/issuance
+      - "10101:10100" # DID              – /
+      - "15251:15151" # identity API     – /api/identity
+      - "15152:15152" # issuer admin API – /api/issuer
+      - "9392:9292"   # STS              – /api/sts
+      - "9999:9999"   # status list      – /statuslist
+    networks:
+      - tractusx-identityhub
+
+networks:
+  tractusx-identityhub:
+    driver: bridge
+
+volumes:
+  pg_data:

--- a/deployment/docker/docker-compose.yaml
+++ b/deployment/docker/docker-compose.yaml
@@ -84,9 +84,7 @@ services:
       dockerfile: Dockerfile
       args:
         JAR: build/libs/identityhub.jar
-        # OTEL_JAR is required by the Dockerfile; the main JAR is used as a
-        # placeholder because the javaagent is disabled in the ENTRYPOINT by default.
-        OTEL_JAR: build/libs/identityhub.jar
+        OTEL_JAR: build/resources/otel/opentelemetry-javaagent.jar
         ADDITIONAL_FILES: build/resources/main/logging.properties
     profiles: [sql]
     depends_on:
@@ -116,7 +114,7 @@ services:
       dockerfile: Dockerfile
       args:
         JAR: build/libs/issuerservice.jar
-        OTEL_JAR: build/libs/issuerservice.jar
+        OTEL_JAR: build/resources/otel/opentelemetry-javaagent.jar
         ADDITIONAL_FILES: build/resources/main/logging.properties
     profiles: [sql]
     depends_on:
@@ -147,7 +145,7 @@ services:
       dockerfile: Dockerfile
       args:
         JAR: build/libs/identityhub-memory.jar
-        OTEL_JAR: build/libs/identityhub-memory.jar
+        OTEL_JAR: build/resources/otel/opentelemetry-javaagent.jar
         ADDITIONAL_FILES: build/resources/main/logging.properties
     profiles: [memory]
     volumes:
@@ -172,7 +170,7 @@ services:
       dockerfile: Dockerfile
       args:
         JAR: build/libs/issuerservice-memory.jar
-        OTEL_JAR: build/libs/issuerservice-memory.jar
+        OTEL_JAR: build/resources/otel/opentelemetry-javaagent.jar
         ADDITIONAL_FILES: build/resources/main/logging.properties
     profiles: [memory]
     volumes:

--- a/deployment/docker/postgres/init/01-create-databases.sh
+++ b/deployment/docker/postgres/init/01-create-databases.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+#  Copyright (c) 2026 Technovative Solutions
 #  Copyright (c) 2026 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional

--- a/deployment/docker/postgres/init/01-create-databases.sh
+++ b/deployment/docker/postgres/init/01-create-databases.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+#  Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Creates the databases required by the SQL runtime variants.
+#  This script runs automatically on the first start of the postgres container via
+#  /docker-entrypoint-initdb.d/.
+#
+
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE DATABASE identityhub;
+    CREATE DATABASE issuerservice;
+EOSQL


### PR DESCRIPTION
## Description

Adds a Docker Compose setup under docker as a developer-friendly alternative to Minikube + Helm for running the project locally.

Closes #287

## Changes

- docker-compose.yaml — two profiles:
  - `memory`: starts `identityhub-memory` + `issuerservice-memory` (no external dependencies)
  - `sql`: starts `identityhub` + `issuerservice` + PostgreSQL 16 + HashiCorp Vault 1.17 (dev mode)
- `deployment/docker/config/<runtime>/configuration.properties` — per-runtime override files mounted into containers (one subdirectory per runtime: `identityhub`, `issuerservice`, `identityhub-memory`, `issuerservice-memory`). SQL variants point datasources at `postgres:5432` and Vault at `http://vault:8200`; SQL configs declare exactly the datasource set each runtime actually loads (per the Helm chart store sets), not a superset
- 01-create-databases.sh — init script that creates the `identityhub` and `issuerservice` databases on first Postgres start
- .env.example — environment variable defaults (credentials, ports); `.env` is gitignored
- README.md — usage guide with prerequisites, run commands, port reference, and cleanup instructions
- INSTALL.md — added "Local development with Docker Compose" section linking to the new README
- CHANGELOG.md — added entry under `[Unreleased] → Added`

## How to test

```bash
# 1. Build JARs (from repo root)
./gradlew shadowJar

# 2. Memory profile
cd deployment/docker
docker compose --profile memory up -d --build

# Verify health (both profiles expose JSON on the default API port)
curl http://localhost:8181/api/check/health   # identityhub-memory
curl http://localhost:8182/api/check/health   # issuerservice-memory
# expected: {"componentResults":[{...,"component":"BaseRuntime","isHealthy":true}],"isSystemHealthy":true}

docker compose --profile memory down

# 3. SQL profile (note: memory & sql profiles share host ports — stop one before the other)
docker compose --profile sql up -d --build

# Verify health (SQL profile additionally reports the Hashicorp Vault component)
curl http://localhost:8181/api/check/health   # identityhub  (SQL + Vault)
curl http://localhost:8182/api/check/health   # issuerservice (SQL + Vault)

# Optionally verify Flyway migrations applied per store
docker exec docker-postgres-1 psql -U postgres -d identityhub   -c "\dt" | grep flyway_schema_history_
docker exec docker-postgres-1 psql -U postgres -d issuerservice -c "\dt" | grep flyway_schema_history_

# Teardown
docker compose --profile sql down -v
```

Verified end-to-end on a fully clean environment (volumes wiped, runtime images removed, `./gradlew clean shadowJar` of all four runtimes): both profiles come up green, zero SEVERE/Exception entries in any runtime log, both health endpoints return `isSystemHealthy:true`. The `edc_lease.resource_id does not exist` issue that previously affected the `sql` profile (#289) was fixed upstream by #291 and is verified resolved here on a clean rebuild.

## Notes

- No existing source files, Dockerfiles, or Helm charts are modified — additive only.
- HashiCorp Vault runs in **dev mode**: data is in-memory and intended for local development only. This is clearly documented.
- The `OTEL_JAR` build argument required by the existing Dockerfiles is satisfied by the OpenTelemetry agent downloaded to `build/resources/otel/opentelemetry-javaagent.jar` during the Gradle build. The javaagent line in each `ENTRYPOINT` is commented out by default, so the agent is copied into the image but not activated at runtime.

---