### PR TITLE
feat: add custom attestation tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ For changes in other Tractus-X components, see the [Eclipse Tractus-X Changelog]
 ## [Unreleased]
 
 ### Added
-
+- Add custom attestation claims table with SQL migration, extension, and configuration for flexible credential issuance by @AYaoZhan in [#299](https://github.com/eclipse-tractusx/tractusx-identityhub/pull/299)
 - Add Docker Compose setup for local development under `deployment/docker/` ([BE-202](https://jira.example.org/browse/BE-202))
 - Add Flyway V0_0_2 migration scripts for EDC 0.15.1 DB schema changes ([#198](https://github.com/eclipse-tractusx/tractusx-identityhub/issues/198)):
   - `credential_resource`: new `usage` column

--- a/charts/tractusx-issuerservice/templates/issuerservice-datasource-config.yaml
+++ b/charts/tractusx-issuerservice/templates/issuerservice-datasource-config.yaml
@@ -109,3 +109,8 @@ data:
   edc.datasource.participantcontextconfig.url: {{ tpl .Values.postgresql.jdbcUrl . | quote }}
   edc.datasource.participantcontextconfig.user: {{ .Values.postgresql.auth.username | quote }}
   edc.datasource.participantcontextconfig.password: {{ .Values.postgresql.auth.password | quote }}
+
+  edc.sql.store.customattestations.datasource: "customattestations"
+  edc.datasource.customattestations.url: {{ tpl .Values.postgresql.jdbcUrl . | quote }}
+  edc.datasource.customattestations.user: {{ .Values.postgresql.auth.username | quote }}
+  edc.datasource.customattestations.password: {{ .Values.postgresql.auth.password | quote }}

--- a/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/store/postgresql/migration/CustomAttestationsMigrationExtension.java
+++ b/extensions/store/sql/migrations/src/main/java/org/eclipse/tractusx/store/postgresql/migration/CustomAttestationsMigrationExtension.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 LKS Next
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.store.postgresql.migration;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.tractusx.store.postgresql.AbstractPostgresqlMigrationExtension;
+
+@Extension("Custom Attestations Migration Extension")
+public class CustomAttestationsMigrationExtension extends AbstractPostgresqlMigrationExtension {
+
+    private static final String NAME_SUBSYSTEM = "customattestations";
+
+    @Inject
+    private Vault vault;
+
+    @Override
+    protected Vault getVault() {
+        return vault;
+    }
+
+    @Override
+    protected String getSubsystemName() {
+        return NAME_SUBSYSTEM;
+    }
+}

--- a/extensions/store/sql/migrations/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/store/sql/migrations/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -24,6 +24,7 @@ org.eclipse.tractusx.store.postgresql.migration.AttestationDefinitionMigrationEx
 org.eclipse.tractusx.store.postgresql.migration.CredentialDefinitionMigrationExtension
 org.eclipse.tractusx.store.postgresql.migration.CredentialOfferMigrationExtension
 org.eclipse.tractusx.store.postgresql.migration.CredentialResourceMigrationExtension
+org.eclipse.tractusx.store.postgresql.migration.CustomAttestationsMigrationExtension
 org.eclipse.tractusx.store.postgresql.migration.DidResourceMigrationExtension
 org.eclipse.tractusx.store.postgresql.migration.HolderCredentialRequestMigrationExtension
 org.eclipse.tractusx.store.postgresql.migration.HoldersMigrationExtension

--- a/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/store/postgresql/customattestations/V0_0_1__Init_CustomAttestations.sql
+++ b/extensions/store/sql/migrations/src/main/resources/org/eclipse/tractusx/store/postgresql/customattestations/V0_0_1__Init_CustomAttestations.sql
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 LKS Next
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+-- only intended for and tested with Postgres!
+CREATE TABLE IF NOT EXISTS custom_attestation_claims
+(
+    holder_id              VARCHAR PRIMARY KEY NOT NULL, -- ID of the Holder (matches participant context)
+    holder_identifier VARCHAR(255),
+    member_of VARCHAR(255),
+    bpn VARCHAR(50),
+    -- Categorization (Renamed from group and userCase)
+    group_name VARCHAR(100),
+    use_case TEXT,
+    -- Contract Metadata
+    contract_template VARCHAR(255),
+    contract_version VARCHAR(50),
+    created_date           BIGINT NOT NULL,              -- POSIX timestamp of creation
+    last_modified_date     BIGINT                        -- POSIX timestamp of last modification
+);
+
+CREATE INDEX IF NOT EXISTS custom_attestation_holder_idx
+    ON custom_attestation_claims(holder_id);
+
+COMMENT ON TABLE custom_attestation_claims IS 'Custom attestation claims for credential issuance. Add/remove columns as needed for your custom claims.';
+COMMENT ON COLUMN custom_attestation_claims.holder_id IS 'Must match the holder ID used in credential issuance requests';

--- a/runtimes/issuerservice/src/main/resources/application.properties
+++ b/runtimes/issuerservice/src/main/resources/application.properties
@@ -107,6 +107,11 @@ edc.datasource.participantcontextconfig.user=
 edc.datasource.participantcontextconfig.password=
 edc.sql.store.participantcontextconfig.datasource=participantcontextconfig
 
+edc.datasource.customattestations.url=
+edc.datasource.customattestations.user=
+edc.datasource.customattestations.password=
+edc.sql.store.customattestations.datasource=customattestations
+
 ###########################
 # ENDPOINTS CONFIGURATION #
 ###########################


### PR DESCRIPTION
## WHAT

Add a new datasource for custom attestation claims. Replicates the same credentialSubjects generated in walletStub.

## WHY

Replicated credentialSubjects is needed to pass VC validations in an end2end data-exchange.

## FURTHER NOTES

This solution is not optimal since it restricts subjectClaims to the specific columns in the table and every new claims forces a modification in the database, therefore a release.

Closes #298
