### PR TITLE
feat(helm): add Gateway API HTTPRoute to IdentityHub and Issuer

### DIFF
--- a/charts/tractusx-identityhub-memory/Chart.yaml
+++ b/charts/tractusx-identityhub-memory/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.3.2
+version: v0.3.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/tractusx-identityhub-memory/templates/httproute.yaml
+++ b/charts/tractusx-identityhub-memory/templates/httproute.yaml
@@ -1,0 +1,63 @@
+#################################################################################
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+{{- $fullName := include "identityhub.fullname" . }}
+{{- $controlLabels := include "identityhub.server.labels" . }}
+{{- $controlEdcEndpoints := .Values.identityhub.endpoints }}
+{{- $namespace := .Release.Namespace }}
+
+{{- range .Values.identityhub.httpRoutes }}
+{{- if and .enabled .endpoints }}
+{{- $routeName := printf "%s-%s" $fullName .hostname }}
+{{- $annotations := .annotations | default dict }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $routeName }}
+  namespace: {{ $namespace }}
+  labels:
+    {{- $controlLabels | nindent 4 }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  hostnames:
+    - {{ .hostname }}
+  rules:
+    {{- $routeEndpoints := .endpoints }}
+    {{- range $name, $mapping := $controlEdcEndpoints }}
+    {{- if (has $name $routeEndpoints) }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ $mapping.path }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $mapping.port }}
+          weight: 1
+    {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tractusx-identityhub-memory/values.yaml
+++ b/charts/tractusx-identityhub-memory/values.yaml
@@ -224,6 +224,48 @@ identityhub:
         issuer: ""
         # -- If preset enables certificate generation via cert-manager cluster-wide issuer
         clusterIssuer: ""
+  ## Gateway API HTTPRoute declarations to expose the network service.
+  ## Each entry mirrors an ingress above, but uses Gateway API instead of Ingress.
+  ## TLS is handled at the Gateway level, not per-route.
+  httpRoutes:
+    ## Public / Internet facing HTTPRoute
+    - enabled: false
+      # -- The hostname to be used to match incoming traffic
+      hostname: "identityhub.presentation.local"
+      # -- Additional HTTPRoute annotations to add
+      annotations: {}
+      # -- IdentityHub endpoints exposed by this HTTPRoute resource
+      endpoints:
+        - credentials
+        - did
+        - sts
+      # -- Gateway parentRefs that this HTTPRoute attaches to
+      parentRefs: []
+      #   - name: gateway
+      #     namespace: gateway-system
+      #     sectionName: http
+      #   - name: gateway
+      #     namespace: gateway-system
+      #     sectionName: https
+    ## HTTPRoute for the Management API, should not be internet facing
+    - enabled: false
+      # -- The hostname to be used to match incoming traffic
+      hostname: "identityhub.identity.local"
+      # -- Additional HTTPRoute annotations to add
+      annotations: {}
+      # -- IdentityHub endpoints exposed by this HTTPRoute resource
+      endpoints:
+        - identity
+        - version
+        - accounts
+      # -- Gateway parentRefs that this HTTPRoute attaches to
+      parentRefs: []
+      #   - name: gateway
+      #     namespace: gateway-system
+      #     sectionName: http
+      #   - name: gateway
+      #     namespace: gateway-system
+      #     sectionName: https
   # -- declare where to mount [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) into the container
   volumeMounts: []
   # -- [volume](https://kubernetes.io/docs/concepts/storage/volumes/) directories

--- a/charts/tractusx-identityhub/Chart.yaml
+++ b/charts/tractusx-identityhub/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.3.2
+version: v0.3.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/tractusx-identityhub/templates/httproute.yaml
+++ b/charts/tractusx-identityhub/templates/httproute.yaml
@@ -1,0 +1,63 @@
+#################################################################################
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+{{- $fullName := include "identityhub.fullname" . }}
+{{- $controlLabels := include "identityhub.server.labels" . }}
+{{- $controlEdcEndpoints := .Values.identityhub.endpoints }}
+{{- $namespace := .Release.Namespace }}
+
+{{- range .Values.identityhub.httpRoutes }}
+{{- if and .enabled .endpoints }}
+{{- $routeName := printf "%s-%s" $fullName .hostname }}
+{{- $annotations := .annotations | default dict }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $routeName }}
+  namespace: {{ $namespace }}
+  labels:
+    {{- $controlLabels | nindent 4 }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  hostnames:
+    - {{ .hostname }}
+  rules:
+    {{- $routeEndpoints := .endpoints }}
+    {{- range $name, $mapping := $controlEdcEndpoints }}
+    {{- if (has $name $routeEndpoints) }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ $mapping.path }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $mapping.port }}
+          weight: 1
+    {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tractusx-identityhub/values.yaml
+++ b/charts/tractusx-identityhub/values.yaml
@@ -249,6 +249,48 @@ identityhub:
         issuer: ""
         # -- If preset enables certificate generation via cert-manager cluster-wide issuer
         clusterIssuer: ""
+  ## Gateway API HTTPRoute declarations to expose the network service.
+  ## Each entry mirrors an ingress above, but uses Gateway API instead of Ingress.
+  ## TLS is handled at the Gateway level, not per-route.
+  httpRoutes:
+    ## Public / Internet facing HTTPRoute for the Presentation API
+    - enabled: false
+      # -- The hostname to be used to match incoming traffic
+      hostname: "identityhub.presentation.local"
+      # -- Additional HTTPRoute annotations to add
+      annotations: {}
+      # -- IdentityHub endpoints exposed by this HTTPRoute resource
+      endpoints:
+        - credentials
+        - did
+        - sts
+      # -- Gateway parentRefs that this HTTPRoute attaches to
+      parentRefs: []
+      #   - name: gateway
+      #     namespace: gateway-system
+      #     sectionName: http
+      #   - name: gateway
+      #     namespace: gateway-system
+      #     sectionName: https
+    ## HTTPRoute for the Identity API, should not be internet facing
+    - enabled: false
+      # -- The hostname to be used to match incoming traffic
+      hostname: "identityhub.identity.local"
+      # -- Additional HTTPRoute annotations to add
+      annotations: {}
+      # -- IdentityHub endpoints exposed by this HTTPRoute resource
+      endpoints:
+        - identity
+        - accounts
+        - version
+      # -- Gateway parentRefs that this HTTPRoute attaches to
+      parentRefs: []
+      #   - name: gateway
+      #     namespace: gateway-system
+      #     sectionName: http
+      #   - name: gateway
+      #     namespace: gateway-system
+      #     sectionName: https
   # -- declare where to mount [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) into the container
   volumeMounts: []
   # -- [volume](https://kubernetes.io/docs/concepts/storage/volumes/) directories

--- a/charts/tractusx-issuerservice-memory/Chart.yaml
+++ b/charts/tractusx-issuerservice-memory/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.3.2
+version: v0.3.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/tractusx-issuerservice-memory/templates/httproute.yaml
+++ b/charts/tractusx-issuerservice-memory/templates/httproute.yaml
@@ -1,0 +1,63 @@
+#################################################################################
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+{{- $fullName := include "issuerservice.fullname" . }}
+{{- $controlLabels := include "issuerservice.server.labels" . }}
+{{- $controlEdcEndpoints := .Values.issuerservice.endpoints }}
+{{- $namespace := .Release.Namespace }}
+
+{{- range .Values.issuerservice.httpRoutes }}
+{{- if and .enabled .endpoints }}
+{{- $routeName := printf "%s-%s" $fullName .hostname }}
+{{- $annotations := .annotations | default dict }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $routeName }}
+  namespace: {{ $namespace }}
+  labels:
+    {{- $controlLabels | nindent 4 }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  hostnames:
+    - {{ .hostname }}
+  rules:
+    {{- $routeEndpoints := .endpoints }}
+    {{- range $name, $mapping := $controlEdcEndpoints }}
+    {{- if (has $name $routeEndpoints) }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ $mapping.path }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $mapping.port }}
+          weight: 1
+    {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tractusx-issuerservice-memory/values.yaml
+++ b/charts/tractusx-issuerservice-memory/values.yaml
@@ -225,6 +225,48 @@ issuerservice:
         issuer: ""
         # -- If preset enables certificate generation via cert-manager cluster-wide issuer
         clusterIssuer: ""
+  ## Gateway API HTTPRoute declarations to expose the network service.
+  ## Each entry mirrors an ingress above, but uses Gateway API instead of Ingress.
+  ## TLS is handled at the Gateway level, not per-route.
+  httpRoutes:
+    ## Public / Internet facing HTTPRoute for the Issuance APIs
+    - enabled: false
+      # -- The hostname to be used to match incoming traffic
+      hostname: "issuerservice.issuance.local"
+      # -- Additional HTTPRoute annotations to add
+      annotations: {}
+      # -- IssuerService endpoints exposed by this HTTPRoute resource
+      endpoints:
+        - issuance
+        - sts
+        - did
+        - statuslist
+      # -- Gateway parentRefs that this HTTPRoute attaches to
+      parentRefs: []
+      #   - name: gateway
+      #     namespace: gateway-system
+      #     sectionName: http
+      #   - name: gateway
+      #     namespace: gateway-system
+      #     sectionName: https
+    ## HTTPRoute for the DID and Admin APIs, should not be internet facing
+    - enabled: false
+      # -- The hostname to be used to match incoming traffic
+      hostname: "issuerservice.did.local"
+      # -- Additional HTTPRoute annotations to add
+      annotations: {}
+      # -- IssuerService endpoints exposed by this HTTPRoute resource
+      endpoints:
+        - issueradmin
+        - identity
+      # -- Gateway parentRefs that this HTTPRoute attaches to
+      parentRefs: []
+      #   - name: gateway
+      #     namespace: gateway-system
+      #     sectionName: http
+      #   - name: gateway
+      #     namespace: gateway-system
+      #     sectionName: https
   # -- declare where to mount [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) into the container
   volumeMounts: []
   # -- [volume](https://kubernetes.io/docs/concepts/storage/volumes/) directories

--- a/charts/tractusx-issuerservice/Chart.yaml
+++ b/charts/tractusx-issuerservice/Chart.yaml
@@ -37,7 +37,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.3.2
+version: v0.3.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/tractusx-issuerservice/templates/httproute.yaml
+++ b/charts/tractusx-issuerservice/templates/httproute.yaml
@@ -1,0 +1,63 @@
+#################################################################################
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+{{- $fullName := include "issuerservice.fullname" . }}
+{{- $controlLabels := include "issuerservice.server.labels" . }}
+{{- $controlEdcEndpoints := .Values.issuerservice.endpoints }}
+{{- $namespace := .Release.Namespace }}
+
+{{- range .Values.issuerservice.httpRoutes }}
+{{- if and .enabled .endpoints }}
+{{- $routeName := printf "%s-%s" $fullName .hostname }}
+{{- $annotations := .annotations | default dict }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $routeName }}
+  namespace: {{ $namespace }}
+  labels:
+    {{- $controlLabels | nindent 4 }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  hostnames:
+    - {{ .hostname }}
+  rules:
+    {{- $routeEndpoints := .endpoints }}
+    {{- range $name, $mapping := $controlEdcEndpoints }}
+    {{- if (has $name $routeEndpoints) }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ $mapping.path }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $mapping.port }}
+          weight: 1
+    {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tractusx-issuerservice/values.yaml
+++ b/charts/tractusx-issuerservice/values.yaml
@@ -257,6 +257,48 @@ issuerservice:
         issuer: ""
         # -- If preset enables certificate generation via cert-manager cluster-wide issuer
         clusterIssuer: ""
+  ## Gateway API HTTPRoute declarations to expose the network service.
+  ## Each entry mirrors an ingress above, but uses Gateway API instead of Ingress.
+  ## TLS is handled at the Gateway level, not per-route.
+  httpRoutes:
+    ## Public / Internet facing HTTPRoute for the Issuance APIs
+    - enabled: false
+      # -- The hostname to be used to match incoming traffic
+      hostname: "issuerservice.issuance.local"
+      # -- Additional HTTPRoute annotations to add
+      annotations: {}
+      # -- IssuerService endpoints exposed by this HTTPRoute resource
+      endpoints:
+        - issuance
+        - sts
+        - did
+        - statuslist
+      # -- Gateway parentRefs that this HTTPRoute attaches to
+      parentRefs: []
+      #   - name: gateway
+      #     namespace: gateway-system
+      #     sectionName: http
+      #   - name: gateway
+      #     namespace: gateway-system
+      #     sectionName: https
+    ## HTTPRoute for the DID and Admin APIs, should not be internet facing
+    - enabled: false
+      # -- The hostname to be used to match incoming traffic
+      hostname: "issuerservice.did.local"
+      # -- Additional HTTPRoute annotations to add
+      annotations: {}
+      # -- IssuerService endpoints exposed by this HTTPRoute resource
+      endpoints:
+        - issueradmin
+        - identity
+      # -- Gateway parentRefs that this HTTPRoute attaches to
+      parentRefs: []
+      #   - name: gateway
+      #     namespace: gateway-system
+      #     sectionName: http
+      #   - name: gateway
+      #     namespace: gateway-system
+      #     sectionName: https
   # -- declare where to mount [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) into the container
   volumeMounts: []
   # -- [volume](https://kubernetes.io/docs/concepts/storage/volumes/) directories


### PR DESCRIPTION
## WHAT

Adds Gateway API HTTPRoute support for the IdentityHub and IssuerService Helm charts.

- `templates/.../httproute.yaml`: new HTTPRoute template, following the same
  pattern as the existing ingress template
- `charts/.../values.yaml`: new httpRoutes block, disabled by default,
  mirroring the layout of the ingress block — two entries per chart:
  (identityhub: presentation API + internet-restricted API;
  issuerservice: issuance + DID resolution)
- `charts/.../Chart.yaml`: version bump to v0.3.3 so the release workflow
  picks up the new parameters
- `README.md`: regenerated with helm-docs to document the new parameters

## WHY

Nginx is not maintained as ingress tooling anymore. The helm charts should therefore be adapted to use the new Gateway API mechanism. The main benefit would be, that with Gateway API, any modern Ingress Controller is supported and could be chosen based on the user and environment. 

**Note** that in this version, TLS and wildcard certificates must be configured and maintained directly on the Gateway — the HTTPRoute templates do not yet cover TLS sections. ListenerSet support will follow as soon as Traefik implements it, see https://github.com/traefik/traefik/issues/12626. Kubernetes and cert-manager already support it.

## Example - Identityhub:

```yaml
ingresses:
    ## Public / Internet facing Ingress for the Presentation API
  - enabled: false
  [...]
httpRoutes:                                                                 
  ## Public / Internet facing HTTPRoute for the Presentation API            
- enabled: true                                                             
  hostname: "identityhub.presentation.example.org" 
  annotations: {}                                                           
  endpoints:                                                                
  - credentials                                                             
  - did                                                                     
  - sts                                                                     
  parentRefs:                                                               
  - name: traefik-gateway                                                   
    namespace: traefik                                                      
    sectionName: web                                                        
  - name: traefik-https                                                     
    namespace: traefik                                                      
    sectionName: websecure                                                  
  ## HTTPRoute for the Identity API, should not be internet facing          
- enabled: true                                                             
  hostname: "identityhub.identity.example.org"     
  annotations: {}                                                           
  endpoints:                                                                
  - identity                                                                
  - accounts                                                                
  - version                                                                 
  parentRefs:                                                               
  - name: traefik-gateway                                                   
    namespace: traefik                                                      
    sectionName: web                                                        
  - name: traefik-https                                                     
    namespace: traefik                                                      
    sectionName: websecure                                                  
    

```

## Example - Issuer:

```yaml
## Ingress declaration to expose the network service.       
ingresses:                                                  
  ## Public / Internet facing Ingress for the Issuance APIs 
- enabled: false                                                              
[...]
httpRoutes:                                                               
  ## Public / Internet facing HTTPRoute for the Issuance APIs             
- enabled: true                                                           
  hostname: "issuerservice.issuance.example.org" 
  annotations: {}                                                         
  endpoints:                                                              
  - issuance                                                              
  - sts                                                                   
  - did                                                                   
  - statuslist                                                            
  parentRefs:                                                             
  - name: traefik-gateway                                                 
    namespace: traefik                                                    
    sectionName: web                                                      
  - name: traefik-https                                                   
    namespace: traefik                                                    
    sectionName: websecure                                                
  ## HTTPRoute for the DID and Admin APIs, should not be internet facing  
- enabled: true                                                           
  hostname: "issuerservice.did.example.org"      
  annotations: {}                                                         
  endpoints:                                                              
  - issueradmin                                                           
  - identity                                                              
  parentRefs:                                                             
  - name: traefik-gateway                                                 
    namespace: traefik                                                    
    sectionName: web                                                      
  - name: traefik-https                                                   
    namespace: traefik                                                    
    sectionName: websecure                                                
                                                                                    

```

## Just for completion - example for Gateway config

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: traefik-https
  namespace: traefik
  annotations:
    cert-manager.io/cluster-issuer: <my_cluster_issuer_via_cert_manager>
spec:
  gatewayClassName: traefik
  listeners:
    # Wildcard listener
    - name: websecure
      protocol: HTTPS
      port: 8443
      hostname: "*.example.org"
      allowedRoutes:
        namespaces:
          from: All
      tls:
        mode: Terminate
        certificateRefs:
          - name: example-org-gateway-tls

    # IssuerService -- issuance API
    - name: issuer-issuance
      protocol: HTTPS
      port: 8443
      hostname: "issuerservice.issuance.example.org"
      allowedRoutes:
        namespaces:
          from: All
      tls:
        mode: Terminate
        certificateRefs:
          - name: issuer-issuance-tls

    # IssuerService -- DID API
    - name: issuer-did
      protocol: HTTPS
      port: 8443
      hostname: "issuerservice.did.example.org"
      allowedRoutes:
        namespaces:
          from: All
      tls:
        mode: Terminate
        certificateRefs:
          - name: issuer-did-tls

    # IdentityHub -- presentation API
    - name: identityhub-presentation
      protocol: HTTPS
      port: 8443
      hostname: "identityhub.presentation.example.org"
      allowedRoutes:
        namespaces:
          from: All
      tls:
        mode: Terminate
        certificateRefs:
          - name: identityhub-presentation-tls

    # IdentityHub -- identity API
    - name: identityhub-identity
      protocol: HTTPS
      port: 8443
      hostname: "identityhub.identity.example.org"
      allowedRoutes:
        namespaces:
          from: All
      tls:
        mode: Terminate
        certificateRefs:
          - name: identityhub-identity-tls

```

## FURTHER NOTES

- The new blocks are fully optional and disabled by default — existing Ingress-based deployments are unaffected.

Closes #345